### PR TITLE
Improved readability of text in subscription box

### DIFF
--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -1846,6 +1846,7 @@ p.question {
 .email-subscribe span {
   display: block;
   margin-top: 12px;
+  color: #cfcfcf;
 }
 .twitter-feed i {
   font-size: 48px;


### PR DESCRIPTION
The text "*We never share your email with 3rd parties" under subscription fields is not readable:
![capture](https://cloud.githubusercontent.com/assets/8400677/12512312/99e33f58-c13d-11e5-944b-e9421101c727.PNG)
