### PR TITLE
Add hover effect to sidebar menu items

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -81,3 +81,10 @@
   margin-top: 4px;
   margin-bottom: 2px;
 }
+
+.sidebar-content .widget ul li a:hover{
+  border-color: #C3BFBF;
+  border-bottom-width: 2px;
+  margin-top: 2px;
+  margin-bottom: 2px;
+}


### PR DESCRIPTION
When the page is initially loaded and is not scrolled, the sidebar menu items did not had a hover effect, it wan't clear which item is user's mouse pointing to but on scrolling a bit the sidebar menu items used to show hover effect.
I added hover effect to the sidebar menu items(when the page isn't scrolled).
