### PR TITLE
Fixed height of gray events dropdown menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
 									<li><a target="_self" href="http://blog.fossasia.org">Blog</a></li>
 									<li><a target="_self" href="http://2017.fossasia.org">FOSSASIA'17</a></li>
 									<li class="has-dropdown"><a href="http://events.fossasia.org">Events</a>
-										<ul class="nav-dropdown">
+										<ul class="nav-dropdown" style="min-height: 400px">
 											<li><a target="_self" href="http://events.fossasia.org/#sponsorship">Sponsorship</a></li>
 											<li><a target="_self" href="http://eventyay.com">FOSSASIA Event Management</a></li>				
 											<li><a href="http://sciencehack.asia" target="_self">Science Hack Asia</a></li>


### PR DESCRIPTION
The only solution I could find was to forcibly set the height value of the dropdown box. So I fixed the height at 400px, using inline styling.
Before:
![aebc7f9d-6c6a-4084-bf75-d4e8bca6b6ac](https://cloud.githubusercontent.com/assets/14184381/18716836/ce0130ca-803b-11e6-8db0-a6a828d3332f.jpg)

After:
![ffc10673-562c-482a-a511-925afba1feed](https://cloud.githubusercontent.com/assets/14184381/18716852/d8f58d50-803b-11e6-9856-cdd345e9d1bd.jpg)
