### PR TITLE
Fixed overlapping of copyright text with other options in the sidebar

### DIFF
--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -715,6 +715,16 @@ nav .container {
   color: rgba(255, 255, 255, 0.5);
   font-size: 12px;
 }
+.copy-text-box {
+  position: relative;
+  height: 250px;
+  width: 100%;
+  color: rgba(255, 255, 255, 0.5);
+}
+.copy-text-bottom {
+  position: absolute;
+  bottom: 5px;
+}
 .text-panel {
   background: #474747;
   padding: 18px;

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
 								<ul class="menu">
 									<li><a class="inner-link" href="#top">Home</a></li>
 									<li><a href="./about" target="_self">About</a></li>
-									<li><a href="http://eventyay.com" target="_self">eventyay Event Management</a></li>									
+									<li><a href="http://eventyay.com" target="_self">Event Management</a></li>									
 									<li><a class="inner-link" href="#labs" target="_self">Labs &amp; Code</a></li>
 									<li><a href="http://github.com/fossasia" target="_self">Contribute</a></li>
 									<!-- <li><a class="inner-link" href="#support" target="_self">Support</a></li><li><a class="inner-link" href="#subscribe" target="_self">Subscribe</a></li> -->
@@ -146,9 +146,11 @@
 								</ul>
 							</div>
 
-							<div class="copy-text">
-								<span>© Copyright 2016 Creative Commons By License, FOSSASIA</span>
-							</div>
+							<div class="copy-text-box">
+                                <div class="copy-text-bottom">
+                                    <span>© Copyright 2016 Creative Commons By License, FOSSASIA</span>
+                                </div>
+                            </div>
 						</div>
 					</div>
 


### PR DESCRIPTION
On minimizing the browser the items in the sidebar were overlapping with
copyright text. Fixed it by sticking the copyright text to the bottom of
the page.
