### PR TITLE
Fix get ticket URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -489,7 +489,7 @@
 							<div class="text-center col-sm-12">
 								<h1>Join us for the FOSSASIA OpenTechSummit<br>&nbsp;from 17th - 19th March 2017 at the Science Centre Singapore!</h1>
 								<span class="uppercase">Don't Wait, Get your tickets right now</span>
-								<a target="_self" class="btn btn-lg" href="http://2017.fossasia.org">FOSSASIA'17</a><a target="_self" class="btn btn-lg" href="http://2017.fossasia.org">Tickets</a>
+								<a target="_self" class="btn btn-lg" href="http://2017.fossasia.org">FOSSASIA'17</a><a target="_self" class="btn btn-lg" href="http://www.eventnook.com/event/fossasia17/register">Tickets</a>
 								<span class="uppercase">Oh, invite your friends too</span>
 								<a target="_self" href="http://facebook.com/fossasia"><i class="icon social_facebook"></i></a>
 								<a target="_self" href="http://twitter.com/fossasia"><i class="icon social_twitter icon-large"></i></a>


### PR DESCRIPTION
I assume the "Get ticket" button for 2017 FOSS event shoul refer directly to [eventnook ticket page](http://www.eventnook.com/event/fossasia17/register).