### PR TITLE
Fixed Copyright Text out of the screen

### DIFF
--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -498,6 +498,7 @@ nav .container {
   width: 100%;
   height: 2px;
   background: rgba(255, 255, 255, 0.3);
+  margin-bottom: 24px;
 }
 .sidebar-menu .bottom-border {
   position: relative;
@@ -663,11 +664,14 @@ nav .container {
   -moz-transform: translate3d(-300px, 0px, 0px);
 }
 .sidebar-content {
-  padding: 0px 24px;
-  margin-top: 24px;
+  background: #333333;
+  position: relative;
+  z-index: 9999;
+  padding-bottom: 1px;
 }
 .widget {
   margin-bottom: 24px;
+  padding: 0px 24px;
 }
 .widget .title {
   font-size: 16px;
@@ -716,14 +720,16 @@ nav .container {
   font-size: 12px;
 }
 .copy-text-box {
-  position: relative;
-  height: 250px;
+  position: absolute;
+  bottom: 0px;
+  left: 0px; 
   width: 100%;
+  padding: 5px 0px;
   color: rgba(255, 255, 255, 0.5);
 }
 .copy-text-bottom {
-  position: absolute;
-  bottom: 5px;
+  left: 24px;
+  position: relative;
 }
 .text-panel {
   background: #474747;

--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -494,6 +494,7 @@ nav .container {
 }
 .bottom-border {
   position: absolute;
+  top:63ps;
   bottom: 2px;
   width: 100%;
   height: 2px;

--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -494,7 +494,7 @@ nav .container {
 }
 .bottom-border {
   position: absolute;
-  top:63ps;
+  top:63px;
   bottom: 2px;
   width: 100%;
   height: 2px;
@@ -503,6 +503,7 @@ nav .container {
 }
 .sidebar-menu .bottom-border {
   position: relative;
+  top: 0px;
   bottom: 0px;
   background: rgba(255, 255, 255, 0.2);
   display: block !important;

--- a/index.html
+++ b/index.html
@@ -119,10 +119,9 @@
 					<div class="bottom-border"></div>
 
 					<div class="sidebar-menu">
-						<img alt="Logo" class="logo" src="img/fossasia-long.png">
-						<div class="bottom-border"></div>
 						<div class="sidebar-content">
-
+							<img alt="Logo" class="logo" src="img/fossasia-long.png">
+							<div class="bottom-border"></div>
 							<div class="widget">
 								<ul class="menu">
 									<li><a class="inner-link" href="#top">Home</a></li>
@@ -149,12 +148,11 @@
 									<li><a href="https://github.com/fossasia" target="_self" ><i class="fa fa-github fa-lg"></i></a></li>
 								</ul>
 							</div>
-
-							<div class="copy-text-box">
-                                <div class="copy-text-bottom">
-                                    <span>© Copyright 2016 Creative Commons By License, FOSSASIA</span>
-                                </div>
-                            </div>
+						</div>
+						<div class="copy-text-box">
+							<div class="copy-text-bottom">
+								<span>© Copyright 2016 Creative Commons By License, FOSSASIA</span>
+							</div>
 						</div>
 					</div>
 


### PR DESCRIPTION
Fixed it considering #67's problem, for the text not to overlapping the other option
## Before
![1](https://cloud.githubusercontent.com/assets/13853515/20464383/079531a8-af79-11e6-83a4-4c212f8244cb.png)
![3](https://cloud.githubusercontent.com/assets/13853515/20464523/24981db8-af7b-11e6-86f7-b00bfbfd657f.png)
## After
![2](https://cloud.githubusercontent.com/assets/13853515/20464476/a588e552-af7a-11e6-9d2c-c474303bbca5.png)
![4](https://cloud.githubusercontent.com/assets/13853515/20464524/24981d7c-af7b-11e6-950a-2ba0a86ae2fb.png)
![6](https://cloud.githubusercontent.com/assets/13853515/20464549/7dbbdb14-af7b-11e6-8c98-a5db18e0ee4d.png)
![5](https://cloud.githubusercontent.com/assets/13853515/20464525/249894aa-af7b-11e6-9bf8-61d6ec8183ba.png)



