### PR TITLE
Fixed Copyright Text in Sidebar

### DIFF
--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -494,13 +494,16 @@ nav .container {
 }
 .bottom-border {
   position: absolute;
+  top:63px;
   bottom: 2px;
   width: 100%;
   height: 2px;
   background: rgba(255, 255, 255, 0.3);
+  margin-bottom: 24px;
 }
 .sidebar-menu .bottom-border {
   position: relative;
+  top: 0px;
   bottom: 0px;
   background: rgba(255, 255, 255, 0.2);
   display: block !important;
@@ -662,12 +665,10 @@ nav .container {
   -webkit-transform: translate3d(-300px, 0px, 0px);
   -moz-transform: translate3d(-300px, 0px, 0px);
 }
-.sidebar-content {
-  padding: 0px 24px;
-  margin-top: 24px;
-}
+
 .widget {
   margin-bottom: 24px;
+  padding: 0px 24px;
 }
 .widget .title {
   font-size: 16px;
@@ -709,21 +710,19 @@ nav .container {
 .instagram-sidebar {
   overflow-y: auto;
 }
-.sidebar-content .copy-text {
-  position: absolute;
-  bottom: 32px;
-  color: rgba(255, 255, 255, 0.5);
-  font-size: 12px;
-}
+
 .copy-text-box {
   position: relative;
-  height: 250px;
-  width: 100%;
+  height:100%;
+  min-height:450px;
+  top:-415px;
+  padding: 5px 0px;
   color: rgba(255, 255, 255, 0.5);
 }
 .copy-text-bottom {
+  left: 24px;
+  bottom:5px;
   position: absolute;
-  bottom: 5px;
 }
 .text-panel {
   background: #474747;

--- a/index.html
+++ b/index.html
@@ -121,40 +121,37 @@
 					<div class="sidebar-menu">
 						<img alt="Logo" class="logo" src="img/fossasia-long.png">
 						<div class="bottom-border"></div>
-						<div class="sidebar-content">
+						<div class="widget">
+							<ul class="menu">
+								<li><a class="inner-link" href="#top">Home</a></li>
+								<li><a href="./about" target="_self">About</a></li>
+								<li><a href="http://eventyay.com" target="_self">Event Management</a></li>									
+								<li><a class="inner-link" href="#labs" target="_self">Labs &amp; Code</a></li>
+								<li><a href="http://github.com/fossasia" target="_self">Contribute</a></li>
+								<!-- <li><a class="inner-link" href="#support" target="_self">Support</a></li><li><a class="inner-link" href="#subscribe" target="_self">Subscribe</a></li> -->
+								<li><a href="http://2017.fossasia.org" target="_self">FOSSASIA'17</a></li>
+								<li><a href="http://blog.fossasia.org" target="_self">Blog</a></li>
+								<li><a href="./donate/" target="self">Donate</a></li>
+								<li><a href="https://groups.google.com/group/fossasia" target="_self">Mailing List</a></li>
+								<li><a href="http://blog.fossasia.org/contact/" target="_self">Contact</a></li>
+							</ul>
+						</div>
 
-							<div class="widget">
-								<ul class="menu">
-									<li><a class="inner-link" href="#top">Home</a></li>
-									<li><a href="./about" target="_self">About</a></li>
-									<li><a href="http://eventyay.com" target="_self">Event Management</a></li>									
-									<li><a class="inner-link" href="#labs" target="_self">Labs &amp; Code</a></li>
-									<li><a href="http://github.com/fossasia" target="_self">Contribute</a></li>
-									<!-- <li><a class="inner-link" href="#support" target="_self">Support</a></li><li><a class="inner-link" href="#subscribe" target="_self">Subscribe</a></li> -->
-									<li><a href="http://2017.fossasia.org" target="_self">FOSSASIA'17</a></li>
-									<li><a href="http://blog.fossasia.org" target="_self">Blog</a></li>
-									<li><a href="./donate/" target="self">Donate</a></li>
-									<li><a href="https://groups.google.com/group/fossasia" target="_self">Mailing List</a></li>
-									<li><a href="http://blog.fossasia.org/contact/" target="_self">Contact</a></li>
-								</ul>
+						<div class="widget">
+							<ul class="social-profiles">
+								<li><a href="http://twitter.com/fossasia" target="_self"><i class="icon social_twitter"></i></a></li>
+								<li><a href="http://facebook.com/fossasia" target="_self"><i class="icon social_facebook"></i></a></li>
+								<li><a href="https://www.youtube.com/channel/UCQprMsG-raCIMlBudm20iLQ" target="_self"><i class="icon social_youtube icon-large"></i></a></li>
+								<li><a href="https://www.flickr.com/photos/fossasia/" target="_self"><i class="icon social_flickr"></i></a></li>
+								<li><a href="https://www.instagram.com/explore/tags/fossasia/" target="_self"><i class="icon social_instagram"></i></a></li>
+								<li><a href="https://github.com/fossasia" target="_self" ><i class="fa fa-github fa-lg"></i></a></li>
+							</ul>
+						</div>
+						
+						<div class="copy-text-box">
+							<div class="copy-text-bottom">
+								<span>© Copyright 2016 Creative Commons By License, FOSSASIA</span>
 							</div>
-
-							<div class="widget">
-								<ul class="social-profiles">
-									<li><a href="http://twitter.com/fossasia" target="_self"><i class="icon social_twitter"></i></a></li>
-									<li><a href="http://facebook.com/fossasia" target="_self"><i class="icon social_facebook"></i></a></li>
-                  					<li><a href="https://www.youtube.com/channel/UCQprMsG-raCIMlBudm20iLQ" target="_self"><i class="icon social_youtube icon-large"></i></a></li>
-                  					<li><a href="https://www.flickr.com/photos/fossasia/" target="_self"><i class="icon social_flickr"></i></a></li>
-                  					<li><a href="https://www.instagram.com/explore/tags/fossasia/" target="_self"><i class="icon social_instagram"></i></a></li>
-									<li><a href="https://github.com/fossasia" target="_self" ><i class="fa fa-github fa-lg"></i></a></li>
-								</ul>
-							</div>
-
-							<div class="copy-text-box">
-                                <div class="copy-text-bottom">
-                                    <span>© Copyright 2016 Creative Commons By License, FOSSASIA</span>
-                                </div>
-                            </div>
 						</div>
 					</div>
 


### PR DESCRIPTION
Based on #67 and #79
The copyright text will always be at the right bottom of the screen in any resolution and in any browser's dimension.
![1](https://cloud.githubusercontent.com/assets/13853515/20464476/a588e552-af7a-11e6-9d2c-c474303bbca5.png)

As long as it doesn't overlap the other option in sidebar.
![2](https://cloud.githubusercontent.com/assets/13853515/20467853/c0a0ca20-afc1-11e6-9866-cc1c71ee0607.png)