### PR TITLE
Fixes #148 to make images of same width and height

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -98,3 +98,6 @@
 .baddition{
   margin-left:  600px;
 }
+.background-image {
+  width: 100%;
+}


### PR DESCRIPTION
Fixes #148 Team member images are made to be of same width and height in smaller screen widths.