### PR TITLE
Fixed hover property for side menu

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -75,12 +75,6 @@
 .social-profiles a:hover i{
   color: grey;
 }
-.sticky-nav .menu li a:hover {
-  border-color: #C3BFBF;
-  border-bottom-width: 2px;
-  margin-bottom: 2px;
-}
-
 .sidebar-content .widget ul li a:hover{
   border-color: #C3BFBF;
   border-bottom-width: 2px;

--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -726,11 +726,12 @@ nav .container {
 }
 .widget .menu li a {
   padding-bottom: 0px;
-  color: #fff !important;
+  color: #fff;
   font-size: 12px;
 }
 .widget .menu li a:hover {
   border-color: rgba(0, 0, 0, 0);
+  color:red;
 }
 .widget .menu .social-link {
   display: none;


### PR DESCRIPTION
Fixed Issue #277 
###Actual Behaviour
Initially the hover property for the side menu does not work on loading the page. On scrolling down and then hovering the tabs get underline hover.
###Expected Behaviour
On hovering the colour changes to red.
###Screenshot
![screen shot 2018-01-15 at 12 42 15 am](https://user-images.githubusercontent.com/31013104/34919610-da802768-f98c-11e7-8587-fcee3e538526.png)
