### PR TITLE
Location marker aligned propely on donate page

### DIFF
--- a/donate/index.html
+++ b/donate/index.html
@@ -458,7 +458,8 @@
 							<ul class="contact-methods">
 								<li><i class="icon pe-7s-mail"></i><span>contact@fossasia.org</span></li>
 								<li><i class="icon pe-7s-phone"></i><span>+65 83435672</span></li>
-								<li><i class="icon pe-7s-map-marker"></i><span>FOSSASIA<br/>6 Eu Tong Sen Street, #5-07 The Central, Singapore 059817</span></li>
+								<li><i class="icon pe-7s-map-marker"></i><span>FOSSASIA</span></li>
+								<li><span>Ms. DANG Hong Phuc</span>6 Eu Tong Sen Street, #5-07 The Central, Singapore 059817</span></li>
 							</ul>
 						</div>
 					</div>


### PR DESCRIPTION
Fixes : #310

Changes : Location Marker Text is aligned properly and added the name "Ms. DANG Hong Phuc"

Screenshot : 
![location marker](https://user-images.githubusercontent.com/32234926/45668601-0370f880-bb3b-11e8-98e6-1e880d50812c.PNG)
