### PR TITLE
Fix the image ratio on "blog posts" section on responsive views

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -87,6 +87,9 @@
   margin-top: 2px;
   margin-bottom: 2px;
 }
+.item .wp-post-image{
+  height: auto;
+}
 @media screen and (min-width: 350px) and (max-width: 440px)
 {
   #DevPrograms{


### PR DESCRIPTION
Issue:
https://gyazo.com/7db3559163f69467743b748a30a6ec66
https://gyazo.com/107a75a17c6cc10718a22511a508529a

Fixed:
https://gyazo.com/2b633c91546407a54041014c05cecdc3 (the images resize accordingly and adapt to small screens without loosing aspect ration)