### PR TITLE
Change paths from relative to absolute in error pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -18,17 +18,17 @@
         <meta name="twitter:creator" content="@fossasia">
         <meta name="twitter:image" content="http://fossasia.github.io/fossasia15/img/fossasia-dark.png">
 
-        <link rel="shortcut icon" href="fossasia.ico" type="image/x-icon" />
-        <link href="css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/flexslider.min.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/elegant-icons.min.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/font-awesome.min.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/pe-icon-7-stroke.min.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/lightbox.min.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/theme-lava.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/custom.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/custom-blog.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/bootstrap-theme.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link rel="shortcut icon" href="/fossasia.ico" type="image/x-icon" />
+        <link href="/css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/flexslider.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/theme-lava.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/elegant-icons.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/font-awesome.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/pe-icon-7-stroke.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/lightbox.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/custom.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/custom-blog.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css" media="all"/>
         
         <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,300' rel='stylesheet' type='text/css'>
 

--- a/500.html
+++ b/500.html
@@ -18,17 +18,17 @@
         <meta name="twitter:creator" content="@fossasia">
         <meta name="twitter:image" content="http://fossasia.github.io/fossasia15/img/fossasia-dark.png">
 
-        <link rel="shortcut icon" href="fossasia.ico" type="image/x-icon" />
-        <link href="css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/flexslider.min.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/elegant-icons.min.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/font-awesome.min.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/pe-icon-7-stroke.min.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/lightbox.min.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/theme-lava.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/custom.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/custom-blog.css" rel="stylesheet" type="text/css" media="all"/>
-        <link href="css/bootstrap-theme.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link rel="shortcut icon" href="/fossasia.ico" type="image/x-icon" />
+        <link href="/css/flexslider.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/elegant-icons.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/font-awesome.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/pe-icon-7-stroke.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/lightbox.min.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/theme-lava.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/custom.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/custom-blog.css" rel="stylesheet" type="text/css" media="all"/>
+        <link href="/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css" media="all"/>
         
         <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,300' rel='stylesheet' type='text/css'>
 


### PR DESCRIPTION
Error pages `404.html` and `500.html` currently only have styling when visiting [https://fossasia.org/randompage](https://fossasia.org/randompage) and not when visiting [https://fossasia.org/apply/randompage](https://fossasia.org/apply/randompage).

This pull request fixes this with absolute paths to the stylesheets in the error pages.