### PR TITLE
Change relative script and navbar links to absolute in error pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -144,14 +144,14 @@
 						<div class="widget">
 							<ul class="menu">
 								<li><a class="inner-link" href="#top">Home</a></li>
-								<li><a href="./about" target="_self">About</a></li>
+								<li><a href="/about" target="_self">About</a></li>
 								<li><a href="http://eventyay.com" target="_self">Event Management</a></li>									
 								<li><a class="inner-link" href="#labs" target="_self">Labs &amp; Code</a></li>
 								<li><a href="http://github.com/fossasia" target="_self">Contribute</a></li>
 								<!-- <li><a class="inner-link" href="#support" target="_self">Support</a></li><li><a class="inner-link" href="#subscribe" target="_self">Subscribe</a></li> -->
 								<li><a href="http://2018.fossasia.org" target="_self">FOSSASIA Summit'18</a></li>
 								<li><a href="http://blog.fossasia.org" target="_self">Blog</a></li>
-								<li><a href="./donate/" target="self">Donate</a></li>
+								<li><a href="/donate/" target="self">Donate</a></li>
 								<li><a href="https://groups.google.com/group/fossasia" target="_self">Mailing List</a></li>
 								<li><a href="http://blog.fossasia.org/contact/" target="_self">Contact</a></li>
 							</ul>
@@ -189,7 +189,7 @@
 						<div class="col-sm-8">
 							<h1 class="text-white">404<br>Not Found</h1>
 							<p class="lead text-white">Oh dear, this Page is not Available</p>
-							<a href="index.html" class="btn btn-white">Take Me Home</a>
+							<a href="/index.html" class="btn btn-white">Take Me Home</a>
 							<a href="https://github.com/fossasia/fossasia.org/issues" class="btn btn-white btn-hollow">Report this error</a>
 						</div>
 						
@@ -205,17 +205,17 @@
 		<div class="footer-container"></div>
 				
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js" ></script>
-        <script src="js/bootstrap.min.js"></script>
-        <script src="js/skrollr.min.js"></script>
-        <script src="js/spectragram.min.js"></script>
-        <script src="js/flexslider.min.js"></script>
-        <script src="js/jquery.plugin.min.js"></script>
-        <script src="js/jquery.countdown.min.js"></script>
-        <script src="js/lightbox.min.js"></script>
-        <script src="js/smooth-scroll.min.js"></script>
-        <script src="js/twitterfetcher.min.js"></script>
-        <script src="js/placeholders.min.js"></script>
-        <script src="js/scripts.js"></script>
+        <script src="/js/bootstrap.min.js"></script>
+        <script src="/js/skrollr.min.js"></script>
+        <script src="/js/spectragram.min.js"></script>
+        <script src="/js/flexslider.min.js"></script>
+        <script src="/js/jquery.plugin.min.js"></script>
+        <script src="/js/jquery.countdown.min.js"></script>
+        <script src="/js/lightbox.min.js"></script>
+        <script src="/js/smooth-scroll.min.js"></script>
+        <script src="/js/twitterfetcher.min.js"></script>
+        <script src="/js/placeholders.min.js"></script>
+        <script src="/js/scripts.js"></script>
     </body>
 </html>
 				

--- a/500.html
+++ b/500.html
@@ -66,13 +66,13 @@
 					
 							<div class="col-md-10 text-right">
 								<ul class="menu">
-										<li class="has-dropdown"><a href="./about">About</a>
+										<li class="has-dropdown"><a href="/about">About</a>
 										<ul class="nav-dropdown" style="min-height: 100px"> <!--whenever you add/remove an option, change the style="min-height:425px" by +- 25px-->
-											<li><a target="_self" href="./about#background">Background & Mission</a></li>
-											<li><a target="_self" href="./licenses">Licenses</a></li>
-											<li><a target="_self" href="./team">Team</a></li>
+											<li><a target="_self" href="/about#background">Background & Mission</a></li>
+											<li><a target="_self" href="/licenses">Licenses</a></li>
+											<li><a target="_self" href="/team">Team</a></li>
 										</ul>
-									<li class="has-dropdown"><a href="./apply/index.html">Apply</a>
+									<li class="has-dropdown"><a href="/apply/index.html">Apply</a>
 										<ul class="nav-dropdown" style="min-height: 175px"> <!--whenever you add/remove an option, change the style="min-height:425px" by +- 25px-->
 											<li><a target="_self" href="/apply-students">University Student Programs/Internships</a></li>
 											<li><a target="_self" href="/apply-pupils">Pre-University Student Programs/Internships</a></li>
@@ -123,7 +123,7 @@
 											<li><a target="_self" href="http://coc.fossasia.org">Code of Conduct</a></li>					
 										</ul>
 									</li>
-									<li class="hidden-sm hidden-xs"><a target="_self" href="./donate/">Donate</a></li>
+									<li class="hidden-sm hidden-xs"><a target="_self" href="/donate/">Donate</a></li>
 									<li class="hidden-sm hidden-xs"><a href="http://blog.fossasia.org/contact/" target="_self">Contact</a></li>											
 									<li class="social-link hidden-md hidden-sm hidden-xs"><a target="_self" href="https://twitter.com/fossasia"><i class="icon social_twitter"></i></a></li>
 									<li class="social-link hidden-md hidden-sm hidden-xs"><a target="_self" href="https://facebook.com/fossasia"><i class="icon social_facebook"></i></a></li>
@@ -139,19 +139,19 @@
 					<div class="bottom-border"></div>
 			
 					<div class="sidebar-menu">
-						<img alt="Logo" class="logo" src="img/fossasia-long.png">
+						<img alt="Logo" class="logo" src="/img/fossasia-long.png">
 						<div class="bottom-border"></div>
 						<div class="widget">
 							<ul class="menu">
 								<li><a class="inner-link" href="#top">Home</a></li>
-								<li><a href="./about" target="_self">About</a></li>
+								<li><a href="/about" target="_self">About</a></li>
 								<li><a href="http://eventyay.com" target="_self">Event Management</a></li>									
 								<li><a class="inner-link" href="#labs" target="_self">Labs &amp; Code</a></li>
 								<li><a href="http://github.com/fossasia" target="_self">Contribute</a></li>
 								<!-- <li><a class="inner-link" href="#support" target="_self">Support</a></li><li><a class="inner-link" href="#subscribe" target="_self">Subscribe</a></li> -->
 								<li><a href="http://2018.fossasia.org" target="_self">FOSSASIA Summit'18</a></li>
 								<li><a href="http://blog.fossasia.org" target="_self">Blog</a></li>
-								<li><a href="./donate/" target="self">Donate</a></li>
+								<li><a href="/donate/" target="self">Donate</a></li>
 								<li><a href="https://groups.google.com/group/fossasia" target="_self">Mailing List</a></li>
 								<li><a href="http://blog.fossasia.org/contact/" target="_self">Contact</a></li>
 							</ul>
@@ -189,7 +189,7 @@
 						<div class="col-sm-8">
 							<h1 class="text-white">500<br>Server Error</h1>
 							<p class="lead text-white">Oh dear, something went wrong...</p>
-							<a href="index.html" class="btn btn-white">Take Me Home</a>
+							<a href="/index.html" class="btn btn-white">Take Me Home</a>
 							<a href="https://github.com/fossasia/fossasia.org/issues" class="btn btn-white btn-hollow">Report this error</a>
 						</div>
 						
@@ -205,17 +205,17 @@
 		<div class="footer-container"></div>
 				
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js" ></script>
-        <script src="js/bootstrap.min.js"></script>
-        <script src="js/skrollr.min.js"></script>
-        <script src="js/spectragram.min.js"></script>
-        <script src="js/flexslider.min.js"></script>
-        <script src="js/jquery.plugin.min.js"></script>
-        <script src="js/jquery.countdown.min.js"></script>
-        <script src="js/lightbox.min.js"></script>
-        <script src="js/smooth-scroll.min.js"></script>
-        <script src="js/twitterfetcher.min.js"></script>
-        <script src="js/placeholders.min.js"></script>
-        <script src="js/scripts.js"></script>
+        <script src="/js/bootstrap.min.js"></script>
+        <script src="/js/skrollr.min.js"></script>
+        <script src="/js/spectragram.min.js"></script>
+        <script src="/js/flexslider.min.js"></script>
+        <script src="/js/jquery.plugin.min.js"></script>
+        <script src="/js/jquery.countdown.min.js"></script>
+        <script src="/js/lightbox.min.js"></script>
+        <script src="/js/smooth-scroll.min.js"></script>
+        <script src="/js/twitterfetcher.min.js"></script>
+        <script src="/js/placeholders.min.js"></script>
+        <script src="/js/scripts.js"></script>
     </body>
 </html>
 				


### PR DESCRIPTION
Error pages `404.html` and `500.html` currently only have scripts and navbar links working when visiting https://fossasia.org/randompage and not when visiting https://fossasia.org/apply/randompage.

This pull request fixes this with absolute paths to the scripts, the images, and the navbar links in the error pages.