### PR TITLE
Split color of color-block for screen size 770-990px (#429)

### DIFF
--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -1285,7 +1285,7 @@ nav .container {
   background-color: #b82300;
   right: 0px;
 }
-@media all and (max-width: 768px) {
+@media all and (max-width: 991px) {
   .block-content {
     margin-bottom: 144px;
     overflow: hidden;


### PR DESCRIPTION
### Description

Made the color-blocks to split color for screen size 770px to 990px .

Issue - #429 
Preview Link - https://ksninja.github.io/temp

### Screenshots
#### Before
<img width="771" alt="screenshot 2018-12-15 at 3 32 32 pm" src="https://user-images.githubusercontent.com/26023139/50041807-b2f93080-0080-11e9-893c-7d4c97be1495.png">

#### After
<img width="897" alt="screenshot 2018-12-15 at 3 47 35 pm" src="https://user-images.githubusercontent.com/26023139/50041813-c6a49700-0080-11e9-98c7-be3fc7250fdc.png">
