### PR TITLE
Remove undesirable spaces from 'EVENTS , CONFERENCE ..' section (#437)

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -247,3 +247,7 @@ nav{
   margin-top: 350px;
 
 }
+.equal-row{
+  display: flex;
+  flex-wrap: wrap;
+}

--- a/index.html
+++ b/index.html
@@ -724,7 +724,7 @@
 								<h1>Events, Conferences, Meetups, Jugaad Fests, Hackathons</h1>
 							</div>
 						</div>
-						<div class="row">
+						<div class="row equal-row">
 
 							<div class="col-md-4 col-sm-6">
 								<div class="info-box">


### PR DESCRIPTION
Remove extra spaces from the 'EVENTS , CONFERENCE ..' section . 

### Description

Preview - https://ksninja.github.io/remove-space-from-tracks/
Issue - #437 

### Screenshots

#### Before
<img width="919" alt="screenshot 2018-12-17 at 5 13 38 pm" src="https://user-images.githubusercontent.com/26023139/50085384-e7efb980-021f-11e9-94a2-444fb38e9f1a.png">

#### After
<img width="916" alt="screenshot 2018-12-17 at 5 19 56 pm" src="https://user-images.githubusercontent.com/26023139/50085442-0eadf000-0220-11e9-952e-7a8ed13764b6.png">
