### PR TITLE
The Navigation Bar wasn't responsive on tablet screen. #386

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -247,3 +247,8 @@ nav{
   margin-top: 350px;
 
 }
+@media screen and (min-width: 768px) and (max-width: 992px){
+  .overlay-nav .menu li{
+    margin-right: 20px;
+  }
+}


### PR DESCRIPTION
Navigation bar buttons were overlapping when we use web app on The Tablet Screen. The Conflict has been resolved.