### PR TITLE
Weird looking negative space in "How can I support Fossasia"section #445

### DIFF
--- a/index.html
+++ b/index.html
@@ -1091,7 +1091,7 @@
 
 					<div class="row">
 
-						<div class="col-md-3 col-sm-4">
+						<div class="col-md-3 col-sm-6">
 							<div class="faq-item">
 								<p class="question">
 								Become a contributor and solve a bug, implement a new feature or write a unit test.
@@ -1099,7 +1099,7 @@
 
 								<p>We are looking for your expertise, be it as a software developer, hardware maker, designer or administrator. Please join us and contribute to our projects on Github. Solving a bug, implementing a new feature, writing unit tests and giving feedback on existing projects is the first step before joining FOSSASIA coding programs.<br><br><a href="http://labs.fossasia.org/#projects" class="inner-link" target="_self">See an overview of projects here</a> <br> <a href="http://codeheat.org" class="inner-link" target="_self">Join our coding contest.</a></p>
 							</div>
-						</div><div class="col-md-3 col-sm-4">
+						</div><div class="col-md-3 col-sm-6">
 							<div class="faq-item">
 								<p class="question">
 									Use FOSSASIA apps, buy hardware and donate to projects.
@@ -1110,7 +1110,7 @@
 							</div>
 						</div>
 
-						<div class="col-md-3 col-sm-4">
+						<div class="col-md-3 col-sm-6">
 							<div class="faq-item">
 								<p class="question">
 								Join OpenTech meetups, become a volunteer and organize own events.
@@ -1121,7 +1121,7 @@
 							</div>
 						</div>
 
-						<div class="col-md-3 col-sm-4">
+						<div class="col-md-3 col-sm-6">
 							<div class="faq-item">
 								<p class="question">
 								Sponsor FOSSASIA events and programs as a company partner.</p>


### PR DESCRIPTION
The "How can I support Fossasia" section now looks good when the screen is resized to the size of a tablet.

Preview Link: [https://itspriyansh.github.io/fossasia.org/](https://itspriyansh.github.io/fossasia.org/)
Issue No: #445 

### Screenshots
**Before**
![screenshot from 2018-12-29 23-00-03](https://user-images.githubusercontent.com/30522149/50540801-9ef41980-0bbe-11e9-98b9-cddec1f3c08f.png)
![screenshot from 2018-12-29 23-00-21](https://user-images.githubusercontent.com/30522149/50540810-ccd95e00-0bbe-11e9-8477-39339894a25e.png)

**After**
![screenshot from 2018-12-29 23-00-52](https://user-images.githubusercontent.com/30522149/50540803-a87d8180-0bbe-11e9-98ea-ba1fd825771e.png)
![screenshot from 2018-12-29 23-00-56](https://user-images.githubusercontent.com/30522149/50540806-b206e980-0bbe-11e9-99d4-35c31cc51731.png)
