### PR TITLE
Add GCI years to submenu (#422)

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -108,10 +108,15 @@
 									<li><a target="_self" href="https://query-server.herokuapp.com/">Query Server</a></li>
 									<li><a target="_self" href="https://knitting.fossasia.org/">Knitting Lab</a></li>
 									<li><a target="_self" href="https://badgeyay.com/">Badgeyay</a></li>
-									<li><a target="_self" href="https://gci17.fossasia.org">Code-In 2017</a></li>
-									<li><a target="_self" href="https://gci16.fossasia.org">Code-In 2016</a></li>
-									<li><a target="_self" href="https://gci15.fossasia.org">Code-In 2015</a></li>
-									<li><a target="_self" href="https://gci14.fossasia.org">Code-In 2014</a></li>
+									<li class="has-dropdown has-submenu"><a>Google CODE-IN</a>
+									    <ul class="nav-dropdown submenu" style="min-height: 161px;">		
+											<li><a target="_self" href="https://gci18.fossasia.org">Code-In 2018</a></li>
+											<li><a target="_self" href="https://gci17.fossasia.org">Code-In 2017</a></li>
+											<li><a target="_self" href="https://gci16.fossasia.org">Code-In 2016</a></li>
+											<li><a target="_self" href="https://gci15.fossasia.org">Code-In 2015</a></li>
+											<li><a target="_self" href="https://gci14.fossasia.org">Code-In 2014</a></li>
+									    </ul>
+									</li>
 								</ul>
 							<li><a target="_self" href="../#subscribe">Subscribe</a></li>
 							<li><a target="_self" href="https://blog.fossasia.org">Blog</a></li>

--- a/apply/index.html
+++ b/apply/index.html
@@ -95,10 +95,15 @@
 											<li><a target="_self" href="https://query-server.herokuapp.com/">Query Server</a></li>
 											<li><a target="_self" href="https://knitting.fossasia.org/">Knitting Lab</a></li>
 											<li><a target="_self" href="https://badgeyay.com/">Badgeyay</a></li>
-											<li><a target="_self" href="https://gci17.fossasia.org">Code-In 2017</a></li>
-											<li><a target="_self" href="https://gci16.fossasia.org">Code-In 2016</a></li>
-											<li><a target="_self" href="https://gci15.fossasia.org">Code-In 2015</a></li>
-											<li><a target="_self" href="https://gci14.fossasia.org">Code-In 2014</a></li>
+											<li class="has-dropdown has-submenu"><a>Google CODE-IN</a>
+									            <ul class="nav-dropdown submenu" style="min-height: 161px;">		
+											        <li><a target="_self" href="https://gci18.fossasia.org">Code-In 2018</a></li>
+											        <li><a target="_self" href="https://gci17.fossasia.org">Code-In 2017</a></li>
+											        <li><a target="_self" href="https://gci16.fossasia.org">Code-In 2016</a></li>
+											        <li><a target="_self" href="https://gci15.fossasia.org">Code-In 2015</a></li>
+											        <li><a target="_self" href="https://gci14.fossasia.org">Code-In 2014</a></li>
+									            </ul>
+									        </li>
 										</ul>
 									<li><a target="_self" class="inner-link" href="../#subscribe">Subscribe</a></li>
 									<li><a target="_self" href="https://blog.fossasia.org">Blog</a></li>

--- a/donate/index.html
+++ b/donate/index.html
@@ -75,10 +75,15 @@
 											<li><a target="_self" href="https://query-server.herokuapp.com/">Query Server</a></li>
 											<li><a target="_self" href="https://knitting.fossasia.org/">Knitting Lab</a></li>
 											<li><a target="_self" href="https://badgeyay.com/">Badgeyay</a></li>
-											<li><a target="_self" href="https://gci17.fossasia.org">Code-In 2017</a></li>
-											<li><a target="_self" href="https://gci16.fossasia.org">Code-In 2016</a></li>
-											<li><a target="_self" href="https://gci15.fossasia.org">Code-In 2015</a></li>
-											<li><a target="_self" href="https://gci14.fossasia.org">Code-In 2014</a></li>
+											<li class="has-dropdown has-submenu"><a>Google CODE-IN</a>
+									            <ul class="nav-dropdown submenu" style="min-height: 161px;">		
+											        <li><a target="_self" href="https://gci18.fossasia.org">Code-In 2018</a></li>
+											        <li><a target="_self" href="https://gci17.fossasia.org">Code-In 2017</a></li>
+											        <li><a target="_self" href="https://gci16.fossasia.org">Code-In 2016</a></li>
+											        <li><a target="_self" href="https://gci15.fossasia.org">Code-In 2015</a></li>
+											        <li><a target="_self" href="https://gci14.fossasia.org">Code-In 2014</a></li>
+									            </ul>
+									        </li>
 										</ul>
 										<li><a target="_self" href="../#subscribe">Subscribe</a></li>
 										<li><a target="_self" href="https://blog.fossasia.org">Blog</a></li>

--- a/licenses/index.html
+++ b/licenses/index.html
@@ -96,10 +96,15 @@
 											<li><a target="_self" href="https://query-server.herokuapp.com/">Query Server</a></li>
 											<li><a target="_self" href="https://knitting.fossasia.org/">Knitting Lab</a></li>
 											<li><a target="_self" href="https://badgeyay.com/">Badgeyay</a></li>
-											<li><a target="_self" href="https://gci17.fossasia.org">Code-In 2017</a></li>
-											<li><a target="_self" href="https://gci16.fossasia.org">Code-In 2016</a></li>
-											<li><a target="_self" href="https://gci15.fossasia.org">Code-In 2015</a></li>
-											<li><a target="_self" href="https://gci14.fossasia.org">Code-In 2014</a></li>
+											<li class="has-dropdown has-submenu"><a>Google CODE-IN</a>
+									            <ul class="nav-dropdown submenu" style="min-height: 161px;">		
+											        <li><a target="_self" href="https://gci18.fossasia.org">Code-In 2018</a></li>
+											        <li><a target="_self" href="https://gci17.fossasia.org">Code-In 2017</a></li>
+											        <li><a target="_self" href="https://gci16.fossasia.org">Code-In 2016</a></li>
+											        <li><a target="_self" href="https://gci15.fossasia.org">Code-In 2015</a></li>
+											        <li><a target="_self" href="https://gci14.fossasia.org">Code-In 2014</a></li>
+									            </ul>
+									        </li>
 										</ul>
 										<li><a target="_self" href="../#subscribe">Subscribe</a></li>
 										<li><a target="_self" href="https://blog.fossasia.org">Blog</a></li>

--- a/team/index.html
+++ b/team/index.html
@@ -101,10 +101,15 @@
 											<li><a target="_self" href="https://query-server.herokuapp.com/">Query Server</a></li>
 											<li><a target="_self" href="https://knitting.fossasia.org/">Knitting Lab</a></li>
 											<li><a target="_self" href="https://badgeyay.com/">Badgeyay</a></li>
-											<li><a target="_self" href="https://gci17.fossasia.org">Code-In 2017</a></li>
-											<li><a target="_self" href="https://gci16.fossasia.org">Code-In 2016</a></li>
-											<li><a target="_self" href="https://gci15.fossasia.org">Code-In 2015</a></li>
-											<li><a target="_self" href="https://gci14.fossasia.org">Code-In 2014</a></li>
+											<li class="has-dropdown has-submenu"><a>Google CODE-IN</a>
+									            <ul class="nav-dropdown submenu" style="min-height: 161px;">		
+											        <li><a target="_self" href="https://gci18.fossasia.org">Code-In 2018</a></li>
+											        <li><a target="_self" href="https://gci17.fossasia.org">Code-In 2017</a></li>
+											        <li><a target="_self" href="https://gci16.fossasia.org">Code-In 2016</a></li>
+											        <li><a target="_self" href="https://gci15.fossasia.org">Code-In 2015</a></li>
+											        <li><a target="_self" href="https://gci14.fossasia.org">Code-In 2014</a></li>
+									            </ul>
+									        </li>
 										</ul>
 										<li><a target="_self" href="../#subscribe">Subscribe</a></li>
 										<li><a target="_self" href="https://blog.fossasia.org">Blog</a></li>


### PR DESCRIPTION
1. Transformed the individual GCI years under 'PROJECTS' tab into a single sub-menu . 
2. Applied this to all sub pages.

Preview link - https://ksninja.github.io/fossasia.org/
Issue - #422 

### Screenshots: After
<img width="1440" alt="screenshot 2019-01-15 at 5 50 33 pm" src="https://user-images.githubusercontent.com/26023139/51180294-17ace280-18ee-11e9-910f-bd42f63c2d0d.png">

