### PR TITLE
fix: White link on top of white background

### DIFF
--- a/index.html
+++ b/index.html
@@ -1273,7 +1273,7 @@
 				<div class="container">
 					<div class="row">
 						<div class="col-sm-12">
-							<h1>Participating in FOSSASIA Coding Programs and Google Summer of&nbsp;Code - Important Points and Expectations. Please find our <a class="text-red" href="https://docs.google.com/document/d/1E4kNgrOSw64R2IAG45JSIgQL9Yxia-mG2dqlRcrUo-U/edit#heading=h.tk1f81imz6al" target="_self">detailed guidelines here</a>.</h1>
+							<h1>Participating in FOSSASIA Coding Programs and Google Summer of&nbsp;Code - Important Points and Expectations. Please find our <a class="text-red" href="https://docs.google.com/document/d/1E4kNgrOSw64R2IAG45JSIgQL9Yxia-mG2dqlRcrUo-U/edit#heading=h.tk1f81imz6al" target="_self" style="color: #E12B00"><u>detailed guidelines here</u></a>.</h1>
 						</div>
 					</div>
 


### PR DESCRIPTION
Fixes #537 

"Detailed Guidelines here" link was not showing up, so I colorized it to 'red' as asked. 