### PR TITLE
Events Dropdown "... Past Events" to "Past Events"

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
 											<li><a target="_self" href="https://thai.opentechsummit.asia">OpenTechSummit Thailand</a></li>
 											<li><a target="_self" href="https://vn.opentechsummit.asia">OpenTechSummit Vietnam</a></li>
 											<li><a target="_self" href="https://jugaadfest.com">Jugaad Fest India</a></li>
-											<li class="has-dropdown has-submenu"><a target="_self" href="https://events.fossasia.org">... Past Events</a>
+											<li class="has-dropdown has-submenu"><a target="_self" href="https://events.fossasia.org/">Past Events</a>
 										        <ul class="nav-dropdown submenu" style="min-height: 380px;">
 											    <li><a target="_self" href="https://2019.fossasia.org">FOSSASIA Summit 2019</a></li>
 											    <li><a target="_self" href="https://2018.fossasia.org">FOSSASIA Summit 2018</a></li>


### PR DESCRIPTION
Past Events in the Events Drop-down in the Header has a sub-menu. So it doesn't seem to need "... "  in it's title.