### PR TITLE
Add missing profile links & fix GitHub logo issue on profiles

### DIFF
--- a/team/index.html
+++ b/team/index.html
@@ -271,6 +271,7 @@
 									<div class="hover-state text-center preserve3d">
 										<div class="social-links vertical-align">
 											<a href="https://github.com/hpdang/"><i class="icon fa fa-github"></i></a>
+											<a href="https://www.facebook.com/hpdang" target="_self"><i class="icon social_facebook"></i></a>
 											<a href="https://twitter.com/hpdang" target="_self"><i class="icon social_twitter"></i></a>
 											<a href="https://www.linkedin.com/in/hongphucdang" target="_self"><i class="icon social_linkedin"></i></a>
 										</div>
@@ -544,6 +545,9 @@
 									<div class="hover-state text-center preserve3d">
 										<div class="social-links vertical-align">
 											<a href="https://github.com/sudheesh001/"><i class="icon fa fa-github"></i></a>>
+											<a href="https://www.facebook.com/sudheesh001"><i class="icon social_facebook"></i></a>
+											<a href="https://twitter.com/sudheesh001?lang=en"><i class="icon social_twitter"></i></a>
+											<a href="https://www.linkedin.com/in/sudheesh001/"><i class="icon social_linkedin"></i></a>
 										</div>
 									</div>
 								</div>
@@ -632,6 +636,7 @@
 									<a href="https://github.com/shubham-padia/"><i class="icon fa fa-github"></i></a>
 									<a href="https://www.facebook.com/padiashubham"><i class="icon social_facebook"></i></a>
 									<a href="https://twitter.com/shubham_p98"><i class="icon social_twitter"></i></a>
+									<a href="https://www.linkedin.com/in/shubham-padia-a11b2013a/"><i class="icon social_linkedin"></i></a>
 								</div>
 							</div>
 						</div>
@@ -716,6 +721,7 @@
 							<div class="hover-state text-center preserve3d">
 								<div class="social-links vertical-align">
 									<a href="https://github.com/isuruAb/"><i class="icon fa fa-github"></i></a>
+									<a href="https://www.facebook.com/isuruAb"><i class="icon social_facebook"></i></a>
 									<a href="https://www.linkedin.com/in/isuruab/"><i class="icon social_linkedin"></i></a>
 								  <a href="https://twitter.com/isuruAb"><i class="icon social_twitter"></i></a>
 								</div>


### PR DESCRIPTION
# Purpose 
The purpose of this PR is to fix the issue #600 and add missing profile links in the team page.

# Approach
- Resolve the issue of the GitHub logo by replacing "icon fa fa-github" with "icon fab fa-github".
- Add missing profile links of the team.

# Preview link
https://kumuditha-udayanga.github.io/fossasia.org/team/

# Screenshots

- Before
<img width="634" alt="Screenshot 2019-12-22 at 16 21 28" src="https://user-images.githubusercontent.com/27630091/71320839-2412c580-24d7-11ea-978c-b2cb39b1c383.png">

- After
<img width="737" alt="Screenshot 2019-12-22 at 16 21 50" src="https://user-images.githubusercontent.com/27630091/71320843-2ffe8780-24d7-11ea-81c7-cbe12e00481f.png">



