### PR TITLE
Add Gitter and Wikipedia buttons to Drop down menu and footer

### DIFF
--- a/coc/index.html
+++ b/coc/index.html
@@ -40,10 +40,10 @@
      ga('create', 'UA-17146009-5', 'auto');
      ga('send', 'pageview');
     </script>
- 
+
     </head>
     <body class="no-loader">
-    
+
     	<div class="loader">
     		<div class="strip-holder">
 				<div class="strip-1"></div>
@@ -51,9 +51,9 @@
 				<div class="strip-3"></div>
     		</div>
     	</div>
-    	
+
     	<a id="top"></a>
-				
+
 		<div class="nav-container">
 
 			<nav class="overlay-nav">
@@ -119,7 +119,7 @@
 										<ul class="nav-dropdown" style="min-height: 330px"> <!--whenever you add/remove an option, change the style="min-height:425px" by +- 25px-->
 											<li><a target="_self" href="https://academy.fossasia.org">Academy</a></li>
 											<li><a target="_self" href="../#programs">Programs & Opportunities</a></li>
-											<li><a target="_self" href="https://jobs.fossasia.org">Job Opportunities</a></li>											
+											<li><a target="_self" href="https://jobs.fossasia.org">Job Opportunities</a></li>
 											<li><a target="_self" href="https://docs.google.com/document/d/1E4kNgrOSw64R2IAG45JSIgQL9Yxia-mG2dqlRcrUo-U/edit#heading=h.tk1f81imz6al">Program Guidelines</a></li>
 											<li><a target="_self" href="https://codeheat.org">Codeheat Contest</a></li>
 											<li><a target="_self" href="../internship">University Internship Program</a></li>
@@ -191,6 +191,8 @@
 								<li><a target="_self" href="https://vk.com/fossasia"><i class="fab fa-vk"></i></a></li>
 								<li><a target="_self" href="https://hub.docker.com/u/fossasia"><i class="fab fa-docker"></i></a></li>
 								<li><a target="_self" href="https://gitlab.com/fossasia"><i class="fab fa-gitlab"></i></a></li>
+								<li><a target="_self" href="https://gitter.im/fossasia"><i class="fab fa-gitter"></i></a></li>
+								<li><a target="_self" href="https://de.wikipedia.org/wiki/FOSSASIA"><i class="fab fa-wikipedia-w"></i></a></li>
 							</ul>
 						</div>
 
@@ -202,51 +204,51 @@
 					</div>
 				</nav>
 
-				
+
 		</div>
 		<div class="main-container"><section class="section-header overlay preserve3d">
-			
+
 				<div class="background-image-holder parallax-background">
 					<img class="background-image" alt="Background Image" src="../img/hero7.jpg">
 				</div>
-				
+
 				<div class="container vertical-align">
 					<div class="row">
 						<div class="col-sm-offset- col-sm-9">
-							
-							
-							
+
+
+
 							<h1 class="text-white">FOSSASIA Code of Conduct</h1>
 							<p class="lead text-white">The FOSSASIA community is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences great successes and continued growth. When you're working with members of the community, we encourage you to follow these guidelines which help steer our interactions and strive to keep FOSSASIA a positive, successful, and growing community.
 							</p>
 						</div>
 					</div>
 				</div>
-				
+
 			</section>
-			
+
 			<section class="color-blocks">
 				<div class="color-block block-left col-sm-12 col-md-12"></div>
-				
-				
+
+
 				<div class="container">
 					<div class="row">
-						<a href="http://labs.fossasia.org/ideas.html" class="block-content" target="_self">  
+						<a href="http://labs.fossasia.org/ideas.html" class="block-content" target="_self">
 							<div class="col-md-2 col-sm-4 text-center">
 								<i class="icon pe-7s-like icon-large"></i>
 							</div>
-						
+
 							<div class="col-sm-8 col-md-8">
 								<h1>FOSSASIA Community</h1>
 								<p>We are Open, Considerate, and Respectful.</p>
 							</div>
 						</a>
-						
-						
+
+
 					</div>
 				</div>
 			</section>
-			
+
 			<section class="duplicatable-content">
 				<div class="container">
 					<div class="row">
@@ -254,18 +256,18 @@
 							<h1>Code of Conduct</h1>
 						</div>
 					</div>
-				
+
 					<div class="row">
 						<div class="col-sm-4 col-md-11">
 							<div class="faq-item">
 								<p class="question">
 									A member of the FOSSASIA community is:
 								</p>
-							
+
 								<p><div><div><span>Open</span><br></div><div>Members of the community are open to collaboration, whether it's on PEPs, patches, problems, or otherwise. We're receptive to constructive comment and criticism, as the experiences and skill sets of other members contribute to the whole of our efforts. We're accepting of all who wish to take part in our activities, fostering an environment where anyone can participate and everyone can make a difference.</div><div><br></div><div>Considerate</div><div>Members of the community are considerate of their peers -- other FOSSASIA users. We're thoughtful when addressing the efforts of others, keeping in mind that often times the labor was completed simply for the good of the community. We're attentive in our communications, whether in person or online, and we're tactful when approaching differing views.</div><div><br></div><div>Respectful</div><div>Members of the community are respectful. We're respectful of others, their positions, their skills, their commitments, and their efforts. We're respectful of the volunteer efforts that permeate the FOSSASIA community. We're respectful of the processes set forth in the community, and we work within them. When we disagree, we are courteous in raising our issues.</div><div><br></div><div>Overall, we're good to each other. We contribute to this community not because we have to, but because we want to. If we remember that, these guidelines will come naturally.</div><div><br></div><div>&nbsp;</div><div><br></div><div>Note</div><div>This document is based on Code of Conduct of the Python Software Foundation: https://www.python.org/psf/codeofconduct/</div><div><br></div><div>&nbsp;</div><div><br></div><div>Anti-Harassment Policy</div><div><br></div><div>Simply having an anti-harassment policy can prevent harassment all by itself and encourages people to attend who have had bad experiences at other events. It also gives event staff instructions on how to handle harassment quickly, with the minimum amount of disruption or bad press for the event.</div><div><br></div><div>FOSSASIA is dedicated to providing harassment-free experience at our events for everyone, regardless of gender, sexual orientation, disability, gender identity, age, race, or religion. We do not tolerate harassment of event participants in any form. Participants asked to stop any harassing behavior are expected to comply immediately. Exhibiting partners at events are also subject to the anti-harassment policy. In particular, exhibitors should not use sexualized images, activities, or other material, or otherwise create a sexualized environment.</div><div><br></div><div>If a participant engages in harassing behavior, the event organizers may take any action they deem appropriate, including warning the offender or expulsion from the event. If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately. Our Event Staff can usually be identified by special badges/attire.</div><div><br></div><div>Please note, while we take all concerns raised seriously, we will use our discretion as to in determining when and how to follow up on reported incidents and may decline to take any further action and/or may direct the participant to other resources for resolution. Event staff will be happy to help participants contact venue/event security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.</div><div><br></div><div>We expect participants to follow these rules at all event venues and related social events.</div><div><br></div><div>License and attribution</div><div>This policy is licensed under the Creative Commons Zero license.</div><div><br></div><div>This policy is based on several other policies, including the Ohio LinuxFest anti-harassment policy, written by Esther Filderman and Beth Lynn Eicher, and the Con Anti-Harassment Project. Mary Gardiner, Valerie Aurora, Sarah Smith, and Donna Benjamin generalized the policies and added supporting material. Many members of LinuxChix, Geek Feminism and other groups contributed to this work.</div></div></p>
 							</div>
-						</div>	
-						
+						</div>
+
 					</div>
 				</div>
 			</section>
@@ -319,13 +321,15 @@
 								<li><a target="_self" href="https://vk.com/fossasia"><i class="fab fa-vk"></i></a></li>
 								<li><a target="_self" href="https://hub.docker.com/u/fossasia"><i class="fab fa-docker"></i></a></li>
  								<li><a target="_self" href="https://gitlab.com/fossasia"><i class="fab fa-gitlab"></i></a></li>
+								<li><a target="_self" href="https://gitter.im/fossasia"><i class="fab fa-gitter"></i></a></li>
+								<li><a target="_self" href="https://de.wikipedia.org/wiki/FOSSASIA"><i class="fab fa-wikipedia-w"></i></a></li>
 							</ul>
 						</div>
 					</div>
 				</div>
 			</footer>
 		</div>
-				
+
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js" ></script>
         <script src="../js/bootstrap.min.js"></script>
         <script src="../js/skrollr.min.js"></script>
@@ -340,4 +344,4 @@
         <script src="../js/scripts.js"></script>
 	<script src="../js/fontawesome.js"></script>
     </body>
-</html>			
+</html>

--- a/index.html
+++ b/index.html
@@ -189,6 +189,8 @@
 								<li><a target="_self" href="https://vk.com/fossasia"><i class="fab fa-vk"></i></a></li>
 								<li><a target="_self" href="https://hub.docker.com/u/fossasia"><i class="fab fa-docker"></i></a></li>
 								<li><a target="_self" href="https://gitlab.com/fossasia"><i class="fab fa-gitlab"></i></a></li>
+								<li><a target="_self" href="https://gitter.im/fossasia"><i class="fab fa-gitter"></i></a></li>
+								<li><a target="_self" href="https://de.wikipedia.org/wiki/FOSSASIA"><i class="fab fa-wikipedia-w"></i></a></li>
 							</ul>
 						</div>
 
@@ -512,7 +514,7 @@
 							</div>
 						</div>
 					</div>
-							
+
 								<div class="col-sm-12 text-center">
 									<span>Find more of our projects on <a href="https://github.com/fossasia">GitHub</a></span>
 								</div>
@@ -685,9 +687,9 @@
 									<li>
 										<a href="img/bodyapps-female-3d.jpg" data-lightbox="true" data-title="Lightbox Image">
 											<div class="background-image-holder">
-												
-												
-												
+
+
+
 												<img class="background-image fill" alt="Lightbox Image" src="img/bodyapps-female-3d.jpg">
 											</div>
 										</a>
@@ -1647,7 +1649,9 @@
 								<li><a target="_self" href="https://vk.com/fossasia"><i class="fab fa-vk"></i></a></li>
 								<li><a target="_self" href="https://hub.docker.com/u/fossasia"><i class="fab fa-docker"></i></a></li>
  								<li><a target="_self" href="https://gitlab.com/fossasia"><i class="fab fa-gitlab"></i></a></li>
-								
+								<li><a target="_self" href="https://gitter.im/fossasia"><i class="fab fa-gitter"></i></a></li>
+								<li><a target="_self" href="https://de.wikipedia.org/wiki/FOSSASIA"><i class="fab fa-wikipedia-w"></i></a></li>
+
 							</ul>
 						</div>
 					</div>

--- a/licenses/index.html
+++ b/licenses/index.html
@@ -117,7 +117,7 @@
 										<ul class="nav-dropdown" style="min-height: 330px"> <!--whenever you add/remove an option, change the style="min-height:425px" by +- 25px-->
 											<li><a target="_self" href="https://academy.fossasia.org">Academy</a></li>
 											<li><a target="_self" href="../#programs">Programs & Opportunities</a></li>
-											<li><a target="_self" href="https://jobs.fossasia.org">Job Opportunities</a></li>											
+											<li><a target="_self" href="https://jobs.fossasia.org">Job Opportunities</a></li>
 											<li><a target="_self" href="https://docs.google.com/document/d/1E4kNgrOSw64R2IAG45JSIgQL9Yxia-mG2dqlRcrUo-U/edit#heading=h.tk1f81imz6al">Program Guidelines</a></li>
 											<li><a target="_self" href="https://codeheat.org">Codeheat Contest</a></li>
 											<li><a target="_self" href="../internship">University Internship Program</a></li>
@@ -189,6 +189,8 @@
 								<li><a target="_self" href="https://vk.com/fossasia"><i class="fab fa-vk"></i></a></li>
 								<li><a target="_self" href="https://hub.docker.com/u/fossasia"><i class="fab fa-docker"></i></a></li>
  								<li><a target="_self" href="https://gitlab.com/fossasia"><i class="fab fa-gitlab"></i></a></li>
+								<li><a target="_self" href="https://gitter.im/fossasia"><i class="fab fa-gitter"></i></a></li>
+								<li><a target="_self" href="https://de.wikipedia.org/wiki/FOSSASIA"><i class="fab fa-wikipedia-w"></i></a></li>
 							</ul>
 						</div>
 
@@ -293,6 +295,8 @@
 								<li><a target="_self" href="https://vk.com/fossasia"><i class="fab fa-vk"></i></a></li>
 								<li><a target="_self" href="https://hub.docker.com/u/fossasia"><i class="fab fa-docker"></i></a></li>
  								<li><a target="_self" href="https://gitlab.com/fossasia"><i class="fab fa-gitlab"></i></a></li>
+								<li><a target="_self" href="https://gitter.im/fossasia"><i class="fab fa-gitter"></i></a></li>
+								<li><a target="_self" href="https://de.wikipedia.org/wiki/FOSSASIA"><i class="fab fa-wikipedia-w"></i></a></li>
 							</ul>
 							</ul>
 						</div>

--- a/team/index.html
+++ b/team/index.html
@@ -122,7 +122,7 @@
 										<ul class="nav-dropdown" style="min-height: 330px"> <!--whenever you add/remove an option, change the style="min-height:425px" by +- 25px-->
 											<li><a target="_self" href="https://academy.fossasia.org">Academy</a></li>
 											<li><a target="_self" href="../#programs">Programs & Opportunities</a></li>
-											<li><a target="_self" href="https://jobs.fossasia.org">Job Opportunities</a></li>											
+											<li><a target="_self" href="https://jobs.fossasia.org">Job Opportunities</a></li>
 											<li><a target="_self" href="https://docs.google.com/document/d/1E4kNgrOSw64R2IAG45JSIgQL9Yxia-mG2dqlRcrUo-U/edit#heading=h.tk1f81imz6al">Program Guidelines</a></li>
 											<li><a target="_self" href="https://codeheat.org">Codeheat Contest</a></li>
 											<li><a target="_self" href="../internship">University Internship Program</a></li>
@@ -194,6 +194,8 @@
 								<li><a target="_self" href="https://vk.com/fossasia"><i class="fab fa-vk"></i></a></li>
 								<li><a target="_self" href="https://hub.docker.com/u/fossasia"><i class="fab fa-docker"></i></a></li>
  								<li><a target="_self" href="https://gitlab.com/fossasia"><i class="fab fa-gitlab"></i></a></li>
+								<li><a target="_self" href="https://gitter.im/fossasia"><i class="fab fa-gitter"></i></a></li>
+								<li><a target="_self" href="https://de.wikipedia.org/wiki/FOSSASIA"><i class="fab fa-wikipedia-w"></i></a></li>
 							</ul>
 						</div>
 
@@ -1217,7 +1219,7 @@
 						<span>Developer</span>
 					</div>
 				</div>
-				
+
 				<div class="col-md-3 col-sm-6 speaker-column">
 					<div class="speaker">
 						<div class="image-holder">
@@ -1911,7 +1913,7 @@
 						<span>Web Developer</span>
 					</div>
 				</div>
-	
+
 					<div class="col-md-3 col-sm-6 speaker-column">
 						<div class="speaker">
 							<div class="image-holder">
@@ -2616,6 +2618,8 @@
 										<li><a target="_self" href="https://vk.com/fossasia"><i class="fab fa-vk"></i></a></li>
 										<li><a target="_self" href="https://hub.docker.com/u/fossasia"><i class="fab fa-docker"></i></a></li>
 										 <li><a target="_self" href="https://gitlab.com/fossasia"><i class="fab fa-gitlab"></i></a></li>
+										<li><a target="_self" href="https://gitter.im/fossasia"><i class="fab fa-gitter"></i></a></li>
+										<li><a target="_self" href="https://de.wikipedia.org/wiki/FOSSASIA"><i class="fab fa-wikipedia-w"></i></a></li>
 									</ul>
 								</div>
 							</div>

--- a/thankyou/index.html
+++ b/thankyou/index.html
@@ -239,6 +239,8 @@
 								<li><a target="_self" href="https://vk.com/fossasia"><i class="fab fa-vk"></i></a></li>
 								<li><a target="_self" href="https://hub.docker.com/u/fossasia"><i class="fab fa-docker"></i></a></li>
  								<li><a target="_self" href="https://gitlab.com/fossasia"><i class="fab fa-gitlab"></i></a></li>
+								<li><a target="_self" href="https://gitter.im/fossasia"><i class="fab fa-gitter"></i></a></li>
+								<li><a target="_self" href="https://de.wikipedia.org/wiki/FOSSASIA"><i class="fab fa-wikipedia-w"></i></a></li>
 							</ul>
 						</div>
 					</div>
@@ -261,8 +263,8 @@
         <script src="../js/tweets.js"></script>
 
         <script src="../js/blog.js"></script>
-					
-	<script src="../js/fontawesome.js"></script>				
+
+	<script src="../js/fontawesome.js"></script>
 
     </body>
 </html>


### PR DESCRIPTION
# Purpose 
The purpose of this PR is to add the Wikipedia and Gitter buttons to the drop-down menu and to the page footer according to the GCI task https://codein.withgoogle.com/tasks/5343137837350912/?sp-organization=5183942706069504&sp-is_beginner=False
Issue #576 

# Approach 
- Add Gitter button to the dropdown menu of the relevant pages.
- Add Wikipedia button to the dropdown menu of the relevant pages.
- Add Wikipedia and Gitter buttons to the footer of the relevant pages.

# Preview
https://kumuditha-udayanga.github.io/fossasia.org/

# Screenshots

<img width="1380" alt="Screenshot 2019-12-31 at 19 34 58" src="https://user-images.githubusercontent.com/27630091/71623767-eb749980-2c04-11ea-8661-52a4758904a5.png">

