### PR TITLE
Fixes #668 : Text get overlapped in code of conduct section of the page

### DIFF
--- a/coc/index.html
+++ b/coc/index.html
@@ -210,9 +210,10 @@
 					<img class="background-image" alt="Background Image" src="../img/hero7.jpg">
 				</div>
 
-				<!-- pagination with <br> creates a blank block to prevent overlapping -->
-				<div class="pagination"><br><br><br><br><br><br><br><br></div>
-				<div class="container vertical-align">
+				<div class="container">
+					<!-- This row class along with height style creates a blank row so as to prevent overlapping of text -->
+					<div class="row" style="height: 100px">
+					</div>
 					<div class="row">
 						<div class="col-sm-offset- col-sm-9">
 							<h1 class="text-white">FOSSASIA Code of Conduct</h1>

--- a/coc/index.html
+++ b/coc/index.html
@@ -210,14 +210,12 @@
 					<img class="background-image" alt="Background Image" src="../img/hero7.jpg">
 				</div>
 
+				<!-- blank-box-big creates a blank block to prevent overlapping -->
+				<div class="blank-box-big"></div>
 				<div class="container vertical-align">
 					<div class="row">
 						<div class="col-sm-offset- col-sm-9">
-
-
-
 							<h1 class="text-white">FOSSASIA Code of Conduct</h1>
-							<br style="line-height:6">
 							<p class="lead text-white">The FOSSASIA community is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences great successes and continued growth. When you're working with members of the community, we encourage you to follow these guidelines which help steer our interactions and strive to keep FOSSASIA a positive, successful, and growing community.
 							</p>
 						</div>

--- a/coc/index.html
+++ b/coc/index.html
@@ -210,8 +210,8 @@
 					<img class="background-image" alt="Background Image" src="../img/hero7.jpg">
 				</div>
 
-				<!-- blank-box-big creates a blank block to prevent overlapping -->
-				<div class="blank-box-big"></div>
+				<!-- pagination with <br> creates a blank block to prevent overlapping -->
+				<div class="pagination"><br><br><br><br><br><br><br><br></div>
 				<div class="container vertical-align">
 					<div class="row">
 						<div class="col-sm-offset- col-sm-9">

--- a/coc/index.html
+++ b/coc/index.html
@@ -217,6 +217,7 @@
 
 
 							<h1 class="text-white">FOSSASIA Code of Conduct</h1>
+							<br style="line-height:6">
 							<p class="lead text-white">The FOSSASIA community is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences great successes and continued growth. When you're working with members of the community, we encourage you to follow these guidelines which help steer our interactions and strive to keep FOSSASIA a positive, successful, and growing community.
 							</p>
 						</div>

--- a/css/custom.css
+++ b/css/custom.css
@@ -216,10 +216,3 @@ nav{
   padding:10px;
 
 }
-/* 
-  blank-box-big adds a block of free space to prevent text overlapping
-*/
-.blank-box-big {
-  display: inline-block;
-  margin: 100px 0;
-}

--- a/css/custom.css
+++ b/css/custom.css
@@ -216,3 +216,10 @@ nav{
   padding:10px;
 
 }
+/* 
+  blank-box-big adds a block of free space to prevent text overlapping
+*/
+.blank-box-big {
+  display: inline-block;
+  margin: 100px 0;
+}


### PR DESCRIPTION
Added line break of 6 lines to prevent overlapping of text with the heading.
line 220: ```<br style="line-height:6">```
The above change fixes #668 

RESULT:
![Screenshot from 2020-02-11 06-17-23](https://user-images.githubusercontent.com/58745044/74203603-34088380-4c96-11ea-9a37-1eba30308e4f.png)
