### PR TITLE
Fixes #673 : Text overlaps with header in License Agreements section of the page

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -216,7 +216,3 @@ nav{
   padding:10px;
 
 }
-.blank-box-big {
-  display: inline-block;
-  margin: 100px 0;
-}

--- a/css/custom.css
+++ b/css/custom.css
@@ -216,3 +216,7 @@ nav{
   padding:10px;
 
 }
+.blank-box-big {
+  display: inline-block;
+  margin: 100px 0;
+}

--- a/licenses/index.html
+++ b/licenses/index.html
@@ -202,7 +202,7 @@
 				<div class="background-image-holder parallax-background">
 					<img class="background-image" alt="Background Image" src="../img/hero7.jpg">
 				</div>
-				<br style="line-height: 15">
+				<div class="blank-box-big"></div>
 				<div class="container vertical-align">
 					<div class="row">
 						<div class="col-sm-offset- col-sm-12">

--- a/licenses/index.html
+++ b/licenses/index.html
@@ -202,7 +202,7 @@
 				<div class="background-image-holder parallax-background">
 					<img class="background-image" alt="Background Image" src="../img/hero7.jpg">
 				</div>
-				<div class="blank-box-big"></div>
+				<div class="pagination"><br><br><br><br><br><br><br></div>
 				<div class="container vertical-align">
 					<div class="row">
 						<div class="col-sm-offset- col-sm-12">

--- a/licenses/index.html
+++ b/licenses/index.html
@@ -202,8 +202,10 @@
 				<div class="background-image-holder parallax-background">
 					<img class="background-image" alt="Background Image" src="../img/hero7.jpg">
 				</div>
-				<div class="pagination"><br><br><br><br><br><br><br></div>
-				<div class="container vertical-align">
+				<div class="container">
+					<!-- Added a row along with height style to prevent the overlapping of text -->
+					<div class="row" style="height: 110px">
+					</div>
 					<div class="row">
 						<div class="col-sm-offset- col-sm-12">
 							<i class="icon pe-7s-global"></i>

--- a/licenses/index.html
+++ b/licenses/index.html
@@ -202,6 +202,7 @@
 				<div class="background-image-holder parallax-background">
 					<img class="background-image" alt="Background Image" src="../img/hero7.jpg">
 				</div>
+				<br style="line-height: 15">
 				<div class="container vertical-align">
 					<div class="row">
 						<div class="col-sm-offset- col-sm-12">


### PR DESCRIPTION
This pull request fixes #673 
Added a line break to prevent text from overlapping with the header

Here are screenshots:
BEFORE

![Screenshot from 2020-02-12 22-06-49](https://user-images.githubusercontent.com/58745044/74356589-9d96a800-4de4-11ea-945c-82b4c5849e3d.png)

AFTER

![Screenshot from 2020-02-12 22-06-06](https://user-images.githubusercontent.com/58745044/74356709-cf0f7380-4de4-11ea-84c4-f4c21288fa6d.png)

Here's the deployed link:
https://bharat-1809.github.io/fossasia.org/licenses