### PR TITLE
Copyright text made visible

### DIFF
--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -767,7 +767,6 @@ nav .container {
 .copy-text-bottom {
   left: 24px;
   bottom:25%;
-  bottom:40px;
   position: absolute;
 }
 .text-panel {

--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -521,6 +521,7 @@ nav .container {
   font-weight: 600;
   position: relative;
   top: 4px;
+  padding-bottom: 10px;
 }
 .menu li:last-child {
   margin-right: 0px;
@@ -765,7 +766,7 @@ nav .container {
 }
 .copy-text-bottom {
   left: 24px;
-  bottom:5%;
+  bottom:25%;
   position: absolute;
 }
 .text-panel {
@@ -2371,6 +2372,7 @@ footer.classic .social-profiles {
 .social-profiles li {
   float: left;
   margin-right: 36px;
+  margin-top: 5%;
 }
 .social-profiles li:last-child {
   margin-right: 0px;

--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -766,11 +766,8 @@ nav .container {
 }
 .copy-text-bottom {
   left: 24px;
-
   bottom:25%;
-
   bottom:40px;
-
   position: absolute;
 }
 .text-panel {

--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -765,7 +765,7 @@ nav .container {
 }
 .copy-text-bottom {
   left: 24px;
-  bottom:5px;
+  bottom:5%;
   position: absolute;
 }
 .text-panel {


### PR DESCRIPTION
Copyright text is now made visible
Solved issue #749

**Before:--**
![Screenshot (46)_LI](https://user-images.githubusercontent.com/57686423/86998104-4c40e800-c1cd-11ea-8057-16969aad6b61.jpg)


**After:--**
![Screenshot (45)_LI](https://user-images.githubusercontent.com/57686423/86998126-5662e680-c1cd-11ea-99c5-facd88a04eb4.jpg)
