### PR TITLE
Fixed Bottom to top button in homepage

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -257,3 +257,21 @@ nav{
   display: flex;
   flex-wrap: wrap;
 }
+
+.scroll-top{
+  position: relative;
+  float: right;
+  right: 20px;
+  top: -40px;
+  font-size: 10px;
+  border: none;
+  z-index: 99;
+  outline: none;
+  background-color: rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  color: white;
+  padding: 10px;
+}
+.scroll-top:hover{
+  background-color: rgba(0, 0, 0, 0.8);
+}

--- a/index.html
+++ b/index.html
@@ -1648,7 +1648,7 @@
 					</div>
 				</div>
 							 <a href="javascript:" id="return-to-top">
- 				<span class="glyphicon glyphicon-chevron-up" style="font-size:20px"></span>
+ 				<span class="glyphicon glyphicon-chevron-up scroll-top" style="font-size:20px"></span>
  			</a>
 			</footer>
 		</div>


### PR DESCRIPTION
Fixes #758 

Here, I removed the existing `Back-to-top` button, & replaced it with the one present in the `https://blog.fossasia.org/`

Previously it, looked like - 
![prev](https://user-images.githubusercontent.com/48355572/87423904-b526c680-c5f8-11ea-93f4-9bd560fb82ea.JPG)

& now,
![new](https://user-images.githubusercontent.com/48355572/87423947-c8d22d00-c5f8-11ea-9e5f-88736a936ee6.JPG)

Type of Change:
- [x] Code
- [x] Bug fix (non-breaking change)

Live preview - [Preview](https://x3nosiz.github.io/fossasia_homepage/)