### PR TITLE
Added multi column menu layout for lower resolution screens.

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -224,7 +224,6 @@ nav{
   position: relative;
 } 
 .submenu{
-  top: 0px;
   left: 100%;
 }
 .has-submenu > a:after{

--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -542,21 +542,32 @@ nav .container {
   border-bottom: 2px solid #fff;
 }
 .nav-dropdown {
+  display: none;
+  min-height: 314px;
   position: absolute;
   z-index: 1;
   opacity: 0;
   background: rgba(255, 255, 255, 0.9);
-  min-width: 200px;
+  min-width: 240px;
   overflow: visible;
   margin-top: -2px;
+  padding-bottom: 20px;
   -webkit-transition: all 0.3s;
+  grid-template-rows: repeat(auto-fit, minmax(40px,1fr)); /*enables multi-column view of menu items for allowing full visibility on lower resolution displays*/
+  grid-auto-flow: column;
+}
+
+@media only screen and (max-width: 560px){ /*enables vertical scroll for menu options on mobile devices*/
+  .nav-dropdown{
+    overflow-y:auto;
+  }
 }
 .projects{
-   min-height:525px;
+  min-height: fit-content; /*resizes menu to fit all content. This eliminates the need to manually increase the menu size everytime a new element is added */
 }
 
 .events{
-   min-height: 450px;
+  min-height:fit-content;
 }
 
 .nav-dropdown li:first-child {
@@ -586,15 +597,8 @@ nav .container {
 }
 
 
-
-.nav-dropdown{
-  display: none;
-  min-height:314px;
-
-}
-
 .has-dropdown:hover > ul{
-  display: block;
+  display: grid;  /*display type of dropdown set to grid to enable multi-column view*/
 }
 
 
@@ -607,6 +611,7 @@ nav .container {
 }
 .has-dropdown:hover .nav-dropdown li a {
   padding-left: 24px;
+  padding-right: 24px;
 }
 .has-dropdown a {
   padding-left: 18px;

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 							<div class="col-md-10 text-right">
 								<ul class="menu">
 									<li class="has-dropdown"><a target="_self" class="inner-link" href="#projects">Projects</a>
-               					         <ul class="nav-dropdown projects" style="min-height: 675px"> <!--whenever you add/remove an option, change the style="min-height:675px" by +- 25px-->
+               					         <ul class="nav-dropdown projects" style="max-height: calc(100vh - 100px);"> <!--This list will resize automatically when an element is added or removed-->
 											<li><a target="_self" href="https://github.com/fossasia">Contribute on Github</a></li>
 											<li><a target="_self" href="https://susi.ai">SUSI.AI</a></li>
 											<li><a target="_self" href="https://pslab.io/">Pocket Science Lab</a></li>
@@ -84,7 +84,7 @@
 									     </ul>
 									</li>
 									<li class="has-dropdown"><a target="_self" href="https://events.fossasia.org">Events</a>
-										<ul class="nav-dropdown events" style="min-height: 500px"> <!--whenever you add/remove an option, change the style="min-height:500px" by +- 25px-->
+										<ul class="nav-dropdown events"style="max-height: calc(100vh - 100px);"> <!--This list will resize automatically when an element is added or removed-->
 											<li><a target="_self" href="https://eventyay.com">Eventyay Platform</a></li>
 											<li><a target="_self" href="https://events.fossasia.org/#sponsorship">Event Sponsorships</a></li>
 											<li><a target="_self" href="https://summit.fossasia.org">FOSSASIA Summit Singapore</a></li>
@@ -115,7 +115,7 @@
 										</ul>
 									</li>
 									<li class="has-dropdown"><a class="inner-link" href="#labs-programs">Programs</a>
-										<ul class="nav-dropdown" style="min-height: 425px"> <!--whenever you add/remove an option, change the style="min-height:425px" by +- 25px-->
+										<ul class="nav-dropdown" style="max-height: calc(100vh - 100px);"> <!--This list will resize automatically when an element is added or removed-->
 											<li><a target="_self" href="https://academy.fossasia.org">Academy</a></li>
 											<li><a target="_self" class="inner-link" href="#programs">Programs & Opportunities</a></li>
 											<li><a target="_self" href="https://jobs.fossasia.org">Job Opportunities</a></li>
@@ -135,7 +135,7 @@
 										<li><a target="_self" href="https://blog.fossasia.org">Blog</a></li>
 										    </li>
 										<li class="has-dropdown"><a target="_self" class="inner-link" href="#about">About</a>
-										<ul class="nav-dropdown" style="min-height: 375px"> <!--whenever you add/remove an option, change the style="min-height:375px" by +- 25px-->
+										<ul class="nav-dropdown" style="max-height: calc(100vh - 100px);"> <!--This list will resize automatically when an element is added or removed-->
 											<li><a target="_self" href="https://community.fossasia.org">Membership</a></li>
 											<li><a target="_self" href="https://jobs.fossasia.org">Jobs</a></li>
 											<li><a target="_self" class="inner-link" href="#activities">Activities</a></li>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -252,8 +252,14 @@ $(document).ready(function() {
 
     })
 
-
-
+    $(".has-submenu").hover(function(){
+        var top = $(this).offset().top - $(window).scrollTop();;        
+        if(top<screen.height/4) {$(".submenu").css("top",'0%');}
+        else {$(".submenu").css("bottom","0%");}
+    },
+    function(){
+        $(".submenu").css({'top':'', 'bottom':''});
+    });
 });
 
 $(window).load(function() {


### PR DESCRIPTION
### This resolves #766 . 
Live Demo: https://shantanumallik.github.io/fossasia.org/

Created a multi column menu layout for lower resolution screens. Earlier, the menu options used to overflow the screen boundary and around half of the menu items were rendered inaccessible as seen in these screenshots.

**EARLIER**

![Overflow-1](https://user-images.githubusercontent.com/63910430/90976984-8e48a200-e55f-11ea-8369-254c70e53697.png)

![Overflow-2](https://user-images.githubusercontent.com/63910430/90977001-a6b8bc80-e55f-11ea-884c-74f0187dee29.png)

**After adding the multi column layout, it looks like this:**

![Fixed-1](https://user-images.githubusercontent.com/63910430/90977905-0d8da400-e567-11ea-9fab-a94f5c0e3362.png)

![Fixed-2](https://user-images.githubusercontent.com/63910430/90977908-11b9c180-e567-11ea-87af-abf8f22b0e05.png)


The menu resizes based on the window size.

**This fix does not affect the user experience on any normal high resolution display.**

As a necessary part of this modification, I have automated the height of the menus, eliminating the need for increasing/decreasing the height by 25px every time an element is added/removed.

I have also added a scrollbar for the menu items only for mobile displays. This allows users to scroll through the menu items which, otherwise, are inaccessible due to menu size overflow.


@mariobehling @hpdang @kushthedude @liveHarshit @rpotter12 Kindly review and merge as and when possible.

 