### PR TITLE
Fixed Typo in subscribe page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1512,7 +1512,7 @@
 							<form class="email-subscribe" ><!-- action="https://freelayers.net/subscribe" method="POST" accept-charset="utf-8"-->
                                 <div class="col-sm-4 newsletter-name">
                                 	<a target="_default" href="https://freelayers.net/subscription?f=bOkSmWCUaboPsmMjkCrPp13VzBnEGyddTZqn892vAexe11eV4hzvYeDZI892X1cewRwyClP6MespDGz8OkG94MtW9Q
-" class="btn">Singup Here</a>
+" class="btn">Signup Here</a>
                          <!--      <input class="form-email signup-email-field" placeholder="Enter your name" type="text" name="name" id="name" required>
                                 </div>
 								<div class="newsletter-email col-sm-5">


### PR DESCRIPTION
The signup button in [here](https://fossasia.org/#subscribe) was wrongly named as 'Singup Here' 