### PR TITLE
Scroll to Top ^ icon aligned  correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -1648,7 +1648,7 @@
 					</div>
 				</div>
 							 <a href="javascript:" id="return-to-top">
- 				<span class="glyphicon glyphicon-chevron-up scroll-top" style="font-size:20px"></span>
+ 				<span class="glyphicon glyphicon-chevron-up scroll-top" style="padding: 35px; font-size:20px;"></span>
  			</a>
 			</footer>
 		</div>


### PR DESCRIPTION
Given a proper padding to the scroll to top icon , which was early aligned totally to left.

**Earlier**

![fossasia web-flaw](https://user-images.githubusercontent.com/46221293/101288069-73522300-381a-11eb-9da9-d68a6f0ebf46.PNG)

**After changes**

![changed](https://user-images.githubusercontent.com/46221293/101288076-7d742180-381a-11eb-81e1-ee5a0c69163a.PNG)
