### PR TITLE
Correct OpenTechSummit China 2019 url fixes issue #839

### DIFF
--- a/index.html
+++ b/index.html
@@ -982,7 +982,7 @@
 									<h3>Tsinghua University Shenzhen<br>21-23 November, 2019</h3>
 									<p>The OpenTechSummit China brings together developers and business representatives for collaborative workshops and talks in China. There are also activities like a visit of the famous hardware district Huaqiang Bei und cultural events.<div><br></div><div><br></div></p>
 									<div class="text-link">
-										<a href="https://opentechsummit.cn" target="_self">Website</a>
+										<a href="https://2019.opentechsummit.cn/" target="_self">Website</a>
 									</div>
 								</div>
 							</div>


### PR DESCRIPTION
I have corrected the url for the OpenTechSummit China, Tsinghua University Shenzhen, 21-23 November, 2019 under the Events 2019 in the home  page. 
fixes #839 