### PR TITLE
Spelling corrected from SingUp Here to SignUp Here

### DIFF
--- a/index.html
+++ b/index.html
@@ -1511,7 +1511,7 @@
 							<form class="email-subscribe" ><!-- action="https://freelayers.net/subscribe" method="POST" accept-charset="utf-8"-->
                                 <div class="col-sm-4 newsletter-name">
                                 	<a target="_default" href="https://freelayers.net/subscription?f=bOkSmWCUaboPsmMjkCrPp13VzBnEGyddTZqn892vAexe11eV4hzvYeDZI892X1cewRwyClP6MespDGz8OkG94MtW9Q
-" class="btn">Singup Here</a>
+" class="btn">SignUp Here</a>
                          <!--      <input class="form-email signup-email-field" placeholder="Enter your name" type="text" name="name" id="name" required>
                                 </div>
 								<div class="newsletter-email col-sm-5">


### PR DESCRIPTION
I corrected the spelling of "SingUp Here" button to "SignUp Here" in index.html file.

- Before correction
 
![Manish-Syal123_fossasia org_ FOSSASIA Website https___fossasia org - Google Chrome 28-09-2022 21_30_19](https://user-images.githubusercontent.com/112818612/192828723-8d449c4d-5ea3-4dfc-8456-b89a3d99b210.png)

- After correction


![FOSSASIA _ Asia's Open Technology Organization - Developing Open Source Software, Open Hardware, Open Design, Open Data, Open Knowledge to Improve People's Life and 1 more page - Personal - Microsoft​ Edge 28-09-2022 21_10_00](https://user-images.githubusercontent.com/112818612/192830075-3f2c19b2-71e2-4b12-bc47-5fd858c81c28.png)
