### PR TITLE
Update README.md - replace twitter for github accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ FOSSASIA develops Open Source software and hardware solutions with a global deve
 
 The organization supports its successful projects as a business incubator and runs coding programs and development contests like [Codeheat](https://codeheat.org) to grow the developer community. 
 
-FOSSASIA's annual [OpenTechSummit](https://2019.fossasia.org) in Singapore is the premier Open Technology event in Asia for developers, tech companies, and contributors. FOSSASIA was founded in 2009 by [Mario Behling](https://twitter.com/mariobehling) and [Hong Phuc Dang](https://twitter.com/hpdang).
+FOSSASIA's annual [OpenTechSummit](https://2019.fossasia.org) in Singapore is the premier Open Technology event in Asia for developers, tech companies, and contributors. FOSSASIA was founded in 2009 by [Mario Behling](https://github.com/mariobehling) and [Hong Phuc Dang](https://github.com/hpdang).
 
 Official website: https://fossasia.org


### PR DESCRIPTION
Twitter is now X and have bad reputation. Use github accounts instead

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Replace Twitter links with GitHub links in the README.md for the founders' profiles to reflect current preferences.

Documentation:
- Update README.md to replace Twitter links with GitHub links for the founders' profiles.

<!-- Generated by sourcery-ai[bot]: end summary -->