### PR TITLE
fix: hide hamburger menu on desktop view

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -210,3 +210,41 @@ nav{
   display: flex;
   flex-wrap: wrap;
 }
+ .x-logo {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+/* Subscribe section X (Twitter) logo */
+.subscribe-x {
+  display: inline-block;
+  margin-top: 20px;
+}
+
+.subscribe-x-icon {
+  width: 48px;     /* 👈 bada size (bird jaisa) */
+  height: 48px;
+  color: #ffffff; /* 👈 pure white */
+  opacity: 0.95;
+}
+/* Social circle base (already matches FB / LinkedIn size) */
+.social-circle {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 8px;
+}
+
+/* X (Twitter) specific */
+.x-circle {
+  background-color: #000;   /* black circle */
+}
+
+.x-icon {
+  width: 26px;
+  height: 26px;
+  color: #fff;              /* white X */
+}

--- a/css/theme-lava.css
+++ b/css/theme-lava.css
@@ -2379,3 +2379,10 @@ footer.classic .social-profiles {
   color: #333333;
   font-size: 20px;
 }
+/* Fix: Hide hamburger menu on desktop view */
+@media (min-width: 1024px) {
+  .sidebar-menu-toggle,
+  .mobile-menu-toggle {
+    display: none !important;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -142,7 +142,27 @@
 										</ul>
 										<li class="hidden-sm hidden-xs"><a target="_self" href="./donate/">Donate</a></li>
 							<!--		<li class="hidden-sm hidden-xs"><a target="_self" href="./contact/">Contact</a></li>  -->
-									<li class="social-link hidden-md hidden-sm hidden-xs"><a target="_self" href="https://twitter.com/fossasia"><i class="icon social_twitter"></i></a></li>
+									<!-- <li class="social-link hidden-md hidden-sm hidden-xs"><a target="_self" href="https://twitter.com/fossasia"><i class="icon social_twitter"></i></a></li> -->
+									<li class="social-link">
+									<a href="https://twitter.com/fossasia"
+										target="_self"
+										aria-label="X (Twitter)">
+										<svg
+										class="x-logo"
+										xmlns="http://www.w3.org/2000/svg"
+										viewBox="0 0 24 24"
+										width="18"
+										height="18">
+										<path
+											d="M18.244 2.25h3.308l-7.227 8.26L22.5 21.75h-6.528l-5.114-6.703L4.89 21.75H1.58l7.73-8.835L1.5 2.25h6.694l4.616 6.055L18.244 2.25zM16.95 19.77h1.833L7.213 4.126H5.246L16.95 19.77z"
+											fill="currentColor"/>
+										</svg>
+									</a>
+									</li>
+
+
+
+
 									<li class="social-link hidden-md hidden-sm hidden-xs"><a target="_self" href="https://facebook.com/fossasia"><i class="icon social_facebook"></i></a></li>
 									<li class="social-link hidden-md hidden-sm hidden-xs"><a target="_self" href="https://www.linkedin.com/company/fossasia"><i class="icon social_linkedin"></i></a></li>
 									<li class="social-link hidden-md hidden-sm hidden-xs"><a target="_self" href="https://github.com/fossasia"><i class="fa fa-github fa-lg"></i></a></li>
@@ -876,7 +896,21 @@
 								<a target="_self" class="btn btn-lg" href="https://events.fossasia.org">FOSSASIA Events</a><a target="_self" class="btn btn-lg" href="https://blog.fossasia.org">Blog</a>
 								<span class="uppercase">Oh, invite your friends too</span>
 								<a target="_blank" href="https://www.facebook.com/fossasia/"><i class="icon social_facebook icon-large"></i></a>
-								<a target="_blank" href="https://twitter.com/fossasia"><i class="icon social_twitter"></i></a>
+								<a href="https://twitter.com/fossasia"
+   target="_blank"
+   aria-label="X (Twitter)"
+   class="social-circle x-circle">
+
+  <svg xmlns="http://www.w3.org/2000/svg"
+       viewBox="0 0 24 24"
+       class="x-icon">
+    <path
+      d="M18.244 2.25h3.308l-7.227 8.26L22.5 21.75h-6.528l-5.114-6.703L4.89 21.75H1.58l7.73-8.835L1.5 2.25h6.694l4.616 6.055L18.244 2.25zM16.95 19.77h1.833L7.213 4.126H5.246L16.95 19.77z"
+      fill="currentColor"/>
+  </svg>
+
+</a>
+
 								<a target="_blank" href="https://de.linkedin.com/company/fossasia"><i class="icon social_linkedin icon-large"></i></a>
 							</div>
 						</div>
@@ -1517,7 +1551,19 @@
 						<div class="row">
 							<div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 text-center">
 								<div class="twitter-feed">
-									<i class="icon social_twitter text-white"></i>
+							<a href="https://twitter.com/fossasia"
+							target="_blank"
+							aria-label="X (Twitter)"
+							class="subscribe-x">
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox="0 0 24 24"
+								class="subscribe-x-icon">
+								<path
+								d="M18.244 2.25h3.308l-7.227 8.26L22.5 21.75h-6.528l-5.114-6.703L4.89 21.75H1.58l7.73-8.835L1.5 2.25h6.694l4.616 6.055L18.244 2.25zM16.95 19.77h1.833L7.213 4.126H5.246L16.95 19.77z"
+								fill="currentColor"/>
+							</svg>
+							</a>
                   <!-- For changing parameters of tweets-feed, please see https://github.com/fossasia/fossasia-loklak-webtweets/blob/gh-pages/README.md for the full documentation -->
 									<div class="tweets-feed" data-count=3 data-from="fossasia">
 									</div>
@@ -1615,7 +1661,23 @@
 					<div class="row ui-sortable">
 						<div class="col-sm-12 text-center">
 							<ul class="social-profiles">
-								<li><a target="_self" href="https://twitter.com/fossasia"><i class="icon social_twitter"></i></a></li>
+									<li class="social-link">
+									<a href="https://twitter.com/fossasia"
+										target="_self"
+										aria-label="X (Twitter)">
+										<svg
+										class="x-logo"
+										xmlns="http://www.w3.org/2000/svg"
+										viewBox="0 0 24 24"
+										width="18"
+										height="18">
+										<path
+											d="M18.244 2.25h3.308l-7.227 8.26L22.5 21.75h-6.528l-5.114-6.703L4.89 21.75H1.58l7.73-8.835L1.5 2.25h6.694l4.616 6.055L18.244 2.25zM16.95 19.77h1.833L7.213 4.126H5.246L16.95 19.77z"
+											fill="currentColor"/>
+										</svg>
+									</a>
+									</li>
+
 								<li><a target="_self" href="https://facebook.com/fossasia"><i class="icon social_facebook"></i></a></li>
 								<li><a target="_self" href="https://linkedin.com/company/fossasia"><i class="icon social_linkedin icon-large"></i></a></li>
 								<li><a target="_self" href="https://youtube.com/fossasiaorg"><i class="icon social_youtube icon-large"></i></a></li>


### PR DESCRIPTION
## What does this PR do?

This PR fixes multiple UI issues related to navigation and social icons.

### Fixes
- Fixes #904: Hides hamburger menu icons on desktop/laptop screens (≥1024px)
- Fixes #908: Updates Twitter icons to the official X logo across all sections
  - Navbar
  - Footer
  - Subscribe / social sections

## Screenshots

### Before
- Twitter bird icon used in social links
- 
<img width="1664" height="78" alt="Screenshot 2026-01-12 204339" src="https://github.com/user-attachments/assets/3a2fd6dc-e339-4589-9957-aea39552b38b" />

- Hamburger menu visible on desktop view
- 
<img width="1635" height="73" alt="image" src="https://github.com/user-attachments/assets/bf1982e2-5cd4-44d6-9052-5e98757e6784" />


### After
- Official X logo with correct size and color across all sections 
- 
<img width="1507" height="64" alt="Screenshot 2026-01-13 003607" src="https://github.com/user-attachments/assets/fae877ac-11bf-424d-8d8a-971fd457c52b" />

<img width="1671" height="129" alt="Screenshot 2026-01-13 003645" src="https://github.com/user-attachments/assets/902c29a4-1cf5-49ef-aa7a-726a6e48cdb3" />

<img width="1890" height="802" alt="Screenshot 2026-01-13 003712" src="https://github.com/user-attachments/assets/e988ed57-599d-4ce9-94eb-e8dc38842230" />


<img width="1891" height="642" alt="Screenshot 2026-01-13 011324" src="https://github.com/user-attachments/assets/5e465f57-327b-441e-b7e0-d7d0208c5d7c" />

- 
- Hamburger menu hidden on desktop view
- 
<img width="1887" height="782" alt="image" src="https://github.com/user-attachments/assets/49f9e98a-2bb6-494f-a504-59f605ab6b69" />


