### PR TITLE
Docs:Add hyperlinks to community resources and Eventyay

### DIFF
--- a/labs/index.html
+++ b/labs/index.html
@@ -395,12 +395,12 @@
 									There are many ways to join the Free and Open Source Technology community. Here are some ideas what you can do to participate in the community. Students who are interested to apply for our coding programs should have an active understanding of Free and Open Source software and FOSSASIA and experience of the technologies used.
 								</p>
 								<ul class="ruled-list">
-									<li>Follow and join FOSSASIA on GitHub.</li>
-									<li>Subscribe to FOSSASIA mailing list and newsletter.</li>
-									<li>Follow FOSSASIA on social media channels and spread information distributed there.</li>
+									<li>Follow and join FOSSASIA on <a href="https://github.com/fossasia">GitHub</a>.</li>
+									<li>Subscribe to FOSSASIA <a href="fossasia@googlegroups.com">mailing list</a> and <a href="http://fossasia.org/#subscribe">newsletter</a>.</li>
+									<li>Follow FOSSASIA on <a href="https://blog.fossasia.org/contact/">social media channels</a> and spread information distributed there.</li>
 									<li>Star FOSSASIA repositories you like to show your support.</li>
-									<li>Join the FOSSASIA chat channels regularly and help people who have questions.</li>
-									<li>Fork FOSSASIA repositories and play around with the project.</li>
+									<li>Join the FOSSASIA <a href="https://gitter.im/fossasia/fossasia">chat channels</a> regularly and help people who have questions.</li>
+									<li>Fork FOSSASIA <a href="https://github.com/orgs/fossasia/repositories">repositories</a> and play around with the project.</li>
 									<li>Set up projects and test them.</li>
 									<li>File bug reports and submit feature requests.</li>
 									<li>Solve a bug or implement a feature.</li>
@@ -408,7 +408,7 @@
 									<li>Write unit tests for FOSSASIA projects.</li>
 									<li>Tweet or write a blog article about a FOSSASIA project.</li>
 									<li>Make a video how to setup or use one of FOSSASIA's applications.</li>
-									<li>Organize a developer meetup on eventyay.com and announce it to the FOSSASIA community (e.g. @fossasia in Twitter).</li>
+									<li>Organize a developer meetup on <a href="https://eventyay.com/">eventyay.com</a> and announce it to the FOSSASIA community (e.g. @fossasia in Twitter).</li>
 									<li>Start a local developer group and announce activities on the Internet.</li>
 									<li>Participate in a tech conference and present a FOSSASIA project.</li>
 								</ul>

--- a/labs/index.html
+++ b/labs/index.html
@@ -397,7 +397,7 @@
 								<ul class="ruled-list">
 									<li>Follow and join FOSSASIA on <a href="https://github.com/fossasia">GitHub</a>.</li>
 									<li>Subscribe to <a href="fossasia@googlegroups.com">FOSSASIA mailing list</a> and <a href="http://fossasia.org/#subscribe">newsletter</a>.</li>
-									<li>Follow on <a href="https://blog.fossasia.org/contact/">FOSSASIA social media channels</a> and spread information distributed there.</li>
+									<li>Follow FOSSASIA on <a href="https://blog.fossasia.org/contact/">social media channels</a> and spread information distributed there.</li>
 									<li>Star FOSSASIA repositories you like to show your support.</li>
 									<li>Join the <a href="https://gitter.im/fossasia/fossasia">FOSSASIA chat channels</a> regularly and help people who have questions.</li>
 									<li>Fork <a href="https://github.com/orgs/fossasia/repositories">FOSSASIA repositories</a> and play around with the project.</li>

--- a/labs/index.html
+++ b/labs/index.html
@@ -396,17 +396,17 @@
 								</p>
 								<ul class="ruled-list">
 									<li>Follow and join FOSSASIA on <a href="https://github.com/fossasia">GitHub</a>.</li>
-									<li>Subscribe to FOSSASIA <a href="fossasia@googlegroups.com">mailing list</a> and <a href="http://fossasia.org/#subscribe">newsletter</a>.</li>
-									<li>Follow FOSSASIA on <a href="https://blog.fossasia.org/contact/">social media channels</a> and spread information distributed there.</li>
+									<li>Subscribe to <a href="fossasia@googlegroups.com">FOSSASIA mailing list</a> and <a href="http://fossasia.org/#subscribe">newsletter</a>.</li>
+									<li>Follow on <a href="https://blog.fossasia.org/contact/">FOSSASIA social media channels</a> and spread information distributed there.</li>
 									<li>Star FOSSASIA repositories you like to show your support.</li>
-									<li>Join the FOSSASIA <a href="https://gitter.im/fossasia/fossasia">chat channels</a> regularly and help people who have questions.</li>
-									<li>Fork FOSSASIA <a href="https://github.com/orgs/fossasia/repositories">repositories</a> and play around with the project.</li>
+									<li>Join the <a href="https://gitter.im/fossasia/fossasia">FOSSASIA chat channels</a> regularly and help people who have questions.</li>
+									<li>Fork <a href="https://github.com/orgs/fossasia/repositories">FOSSASIA repositories</a> and play around with the project.</li>
 									<li>Set up projects and test them.</li>
 									<li>File bug reports and submit feature requests.</li>
 									<li>Solve a bug or implement a feature.</li>
 									<li>Do a FOSSASIA mini-project.</li>
 									<li>Write unit tests for FOSSASIA projects.</li>
-									<li>Tweet or write a blog article about a FOSSASIA project.</li>
+									<li>Post on X or write a blog article about a FOSSASIA project.</li>
 									<li>Make a video how to setup or use one of FOSSASIA's applications.</li>
 									<li>Organize a developer meetup on <a href="https://eventyay.com/">eventyay.com</a> and announce it to the FOSSASIA community (e.g. @fossasia in Twitter).</li>
 									<li>Start a local developer group and announce activities on the Internet.</li>
@@ -532,7 +532,7 @@
 							<div class="faq-item">
 								<p class="question">Join an OpenTech event or organize your own. </p>
 								<p>
-								FOSSASIA groups and projects exist throughout Asia. Still there are many white spots left, where you can help to spread free knowledge and Open Technology tools. Why not put together a FOSSASIA developers event and and meet like-minded contributors to talk about coding projects? Organize an event with our Open Source event tool eventyay.com and share it on social media channels - tweet it @fossasia.<br><br><a href="https://eventyay.com" target="_self">Join OpenTech events or organize your own with eventyay.com</a>
+								FOSSASIA groups and projects exist throughout Asia. Still there are many white spots left, where you can help to spread free knowledge and Open Technology tools. Why not put together a FOSSASIA developers event and meet like-minded contributors to talk about coding projects? Organize an event with our Open Source event tool eventyay.com and share it on social media! Don't forget to tag us @fossasia.<br><br><a href="https://eventyay.com" target="_self">Join OpenTech events or organize your own with eventyay.com</a>
 								</p>
 							</div>
 						</div>


### PR DESCRIPTION
Issue no: #910 
Documentation:
- Link FOSSASIA references on GitHub, mailing list, newsletter, social media, chat, and repositories directly from the participation guidance text.

## Summary by Sourcery

Update participation guidance documentation with direct links to FOSSASIA community channels and Eventyay.

Documentation:
- Add hyperlinks to FOSSASIA GitHub, mailing list, newsletter, social media, chat, and repositories in the participation section.
- Refresh wording around social media posts and Eventyay meetups in the participation and FAQ sections.