### PR TITLE
fix: remove dead Play Store links for unavailable Android apps

### DIFF
--- a/index.html
+++ b/index.html
@@ -763,14 +763,13 @@
 
 							<div class="col-md-4 col-sm-6 col-xs-12 sponsor-column"  >
 								<div class=" text-center" style="margin-bottom: 30px">
-									<a href="https://play.google.com/store/apps/details?id=ai.susi">
+									<a href="https://github.com/fossasia/susi_android">
 										<img alt="SUSI.AI"  class="img-responsive" src="img/SUSI.AI-Android.jpg" height="500">
                     <div class="text-block">
     										<h4 class="text-white"><strong>SUSI.AI Android</strong></h4>
  										</div>
 									</a>
                   <div style="display: flex;flex-direction: row;justify-content: center; align-items: center;">
-										<a href='https://play.google.com/store/apps/details?id=ai.susi'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' width="125"/></a>
 										<a href='https://f-droid.org/en/packages/ai.susi/'><img alt='Get it on F-Droid' src='https://fdroid.gitlab.io/artwork/badge/get-it-on.png' width="125"/></a>
                     					<a href='https://github.com/fossasia/susi_android'><img alt="GitHub" src="img/GitHub.png" height="35"></a>
 									</div>
@@ -795,14 +794,13 @@
 
 							<div class="col-md-4 col-sm-6 col-xs-12 sponsor-column" >
 								<div class=" text-center" style="margin-bottom: 30px">
-									<a href="https://play.google.com/store/apps/details?id=org.fossasia.phimpme">
+									<a href="https://github.com/fossasia/phimpme-android">
 										<img alt="Phimpme" src="img/Phimpme_Android.jpg"class="img-responsive">
                     <div class="text-block">
     										<h4 class="text-white"><strong>Phimp.me Android</strong></h4>
  										</div>
 									</a>
                   <div style="display: flex;flex-direction: row;justify-content: center; align-items: center;">
-										<a href='https://play.google.com/store/apps/details?id=org.fossasia.phimpme'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' width="125"/></a>
                     					<a href='https://github.com/fossasia/phimpme-android'><img alt="GitHub" src="img/GitHub.png" height="35"></a>
 									</div>
 								</div>
@@ -826,14 +824,13 @@
 							</div>
 							<div class="col-md-4 col-sm-6 col-xs-12 sponsor-column"  >
 								<div class=" text-center" style="margin-bottom: 30px">
-									<a href="https://play.google.com/store/apps/details?id=com.eventyay.attendee">
+									<a href="https://github.com/fossasia/open-event-attendee-android">
 										<img alt="Eventyay Attendee" src="img/Eventyay_Attendee_App.jpg" class="img-responsive">
                     <div class="text-block">
     										<h4 class="text-white"><strong>Eventyay Attendee App</strong></h4>
  										</div>
 									</a>
                   <div style="display: flex;flex-direction: row;justify-content: center; align-items: center;">
-										<a href='https://play.google.com/store/apps/details?id=com.eventyay.attendee'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' width="125"/></a>
 										<a href='https://f-droid.org/en/packages/com.eventyay.attendee/'><img alt='Get it on F-Droid' src='https://fdroid.gitlab.io/artwork/badge/get-it-on.png' width="125"/></a>
                     					<a href='https://github.com/fossasia/open-event-attendee-android'><img alt="GitHub" src="img/GitHub.png" height="35"></a>
 									</div>
@@ -841,14 +838,13 @@
 							</div>
 							<div class="col-md-4 col-sm-6 col-xs-12 sponsor-column"  >
 								<div class=" text-center" style="margin-bottom: 30px">
-									<a href="https://play.google.com/store/apps/details?id=com.eventyay.organizer">
+									<a href="https://github.com/fossasia/open-event-organizer-android">
 										<img alt="Eventyay Organizer" src="img/Eventyay_Organizer_App.jpg" class="img-responsive">
 										<div class="text-block">
     										<h4 class="text-white"><strong>Eventyay Organizer App</strong></h4>
  										</div>
 									</a>
 									<div style="display: flex;flex-direction: row;justify-content: center; align-items: center;">
-										<a href='https://play.google.com/store/apps/details?id=com.eventyay.organizer'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' width="125"/></a>
 										<a href='https://f-droid.org/en/packages/com.eventyay.organizer/'><img alt='Get it on F-Droid' src='https://fdroid.gitlab.io/artwork/badge/get-it-on.png' width="125"/></a>
                   						<a href='https://github.com/fossasia/open-event-organizer-android'><img alt="GitHub" src="img/GitHub.png" height="35"></a>
                  					 </div>

--- a/index1.html
+++ b/index1.html
@@ -528,14 +528,13 @@
 
 							<div class="col-md-4 col-sm-6 col-xs-12 sponsor-column"  >
 								<div class=" text-center" style="margin-bottom: 30px">
-									<a href="https://play.google.com/store/apps/details?id=ai.susi">
+									<a href="https://github.com/fossasia/susi_android">
 										<img alt="SUSI.AI"  class="img-responsive" src="img/SUSI.AI-Android.jpg" height="500">
                     <div class="text-block">
     										<h4 class="text-white"><strong>SUSI.AI Android</strong></h4>
  										</div>
 									</a>
                   <div style="display: flex;flex-direction: row;justify-content: center; align-items: center;">
-										<a href='https://play.google.com/store/apps/details?id=ai.susi'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' width="125"/></a>
 										<a href='https://f-droid.org/en/packages/ai.susi/'><img alt='Get it on F-Droid' src='https://fdroid.gitlab.io/artwork/badge/get-it-on.png' width="125"/></a>
                     					<a href='https://github.com/fossasia/susi_android'><img alt="GitHub" src="img/GitHub.png" height="35"></a>
 									</div>
@@ -560,14 +559,13 @@
 
 							<div class="col-md-4 col-sm-6 col-xs-12 sponsor-column" >
 								<div class=" text-center" style="margin-bottom: 30px">
-									<a href="https://play.google.com/store/apps/details?id=org.fossasia.phimpme">
+									<a href="https://github.com/fossasia/phimpme-android">
 										<img alt="Phimp.me" src="img/Phimpme_Android.jpg"class="img-responsive">
                     <div class="text-block">
     										<h4 class="text-white"><strong>Phimp.me Android</strong></h4>
  										</div>
 									</a>
                   <div style="display: flex;flex-direction: row;justify-content: center; align-items: center;">
-										<a href='https://play.google.com/store/apps/details?id=org.fossasia.phimpme'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' width="125"/></a>
                     					<a href='https://github.com/fossasia/phimpme-android'><img alt="GitHub" src="img/GitHub.png" height="35"></a>
 									</div>
 								</div>
@@ -591,14 +589,13 @@
 							</div>
 							<div class="col-md-4 col-sm-6 col-xs-12 sponsor-column"  >
 								<div class=" text-center" style="margin-bottom: 30px">
-									<a href="https://play.google.com/store/apps/details?id=com.eventyay.attendee">
+									<a href="https://github.com/fossasia/open-event-attendee-android">
 										<img alt="Eventyay Attendee" src="img/Eventyay_Attendee_App.jpg" class="img-responsive">
                     <div class="text-block">
     										<h4 class="text-white"><strong>Eventyay Attendee App</strong></h4>
  										</div>
 									</a>
                   <div style="display: flex;flex-direction: row;justify-content: center; align-items: center;">
-										<a href='https://play.google.com/store/apps/details?id=com.eventyay.attendee'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' width="125"/></a>
 										<a href='https://f-droid.org/en/packages/com.eventyay.attendee/'><img alt='Get it on F-Droid' src='https://fdroid.gitlab.io/artwork/badge/get-it-on.png' width="125"/></a>
                     					<a href='https://github.com/fossasia/open-event-attendee-android'><img alt="GitHub" src="img/GitHub.png" height="35"></a>
 									</div>
@@ -606,14 +603,13 @@
 							</div>
 							<div class="col-md-4 col-sm-6 col-xs-12 sponsor-column"  >
 								<div class=" text-center" style="margin-bottom: 30px">
-									<a href="https://play.google.com/store/apps/details?id=com.eventyay.organizer">
+									<a href="https://github.com/fossasia/open-event-organizer-android">
 										<img alt="Eventyay Organizer" src="img/Eventyay_Organizer_App.jpg" class="img-responsive">
 										<div class="text-block">
     										<h4 class="text-white"><strong>Eventyay Organizer App</strong></h4>
  										</div>
 									</a>
 									<div style="display: flex;flex-direction: row;justify-content: center; align-items: center;">
-										<a href='https://play.google.com/store/apps/details?id=com.eventyay.organizer'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' width="125"/></a>
 										<a href='https://f-droid.org/en/packages/com.eventyay.organizer/'><img alt='Get it on F-Droid' src='https://fdroid.gitlab.io/artwork/badge/get-it-on.png' width="125"/></a>
                   						<a href='https://github.com/fossasia/open-event-organizer-android'><img alt="GitHub" src="img/GitHub.png" height="35"></a>
                  					 </div>


### PR DESCRIPTION
## Description
This PR removes or replaces dead Google Play Store links in the Android Apps
section that currently return 404 errors, and updates them to valid GitHub
sources where appropriate.

## Changes
- Removed Play Store badges for unavailable Android apps
- Replaced broken navigation links with valid GitHub sources
- Limited modifications only to the Android Apps section

## Issue
Fixes #858

## Summary by Sourcery

Update Android app links to remove dead Google Play Store entries and point users to maintained sources.

Bug Fixes:
- Remove broken Google Play Store badges and links for SUSI.AI, Phimp.me, Eventyay Attendee, and Eventyay Organizer Android apps.
- Update primary Android app tiles to link directly to the corresponding GitHub repositories instead of unavailable Play Store listings.