### PR TITLE
fix: replace defunct travis-ci.org badge with GitHub Actions badge #917

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FOSSASIA.org
 
-[![Build Status](https://travis-ci.org/fossasia/fossasia.org.svg?branch=gh-pages)](https://travis-ci.org/fossasia/fossasia.org) [![Join the chat at https://gitter.im/fossasia/fossasia](https://badges.gitter.im/fossasia/fossasia.svg)](https://gitter.im/fossasia/fossasia?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://github.com/fossasia/fossasia.org/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/fossasia/fossasia.org/actions/workflows/pages/pages-build-deployment) [![Join the chat at https://gitter.im/fossasia/fossasia](https://badges.gitter.im/fossasia/fossasia.svg)](https://gitter.im/fossasia/fossasia?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Mailing List](https://img.shields.io/badge/Mailing%20List-FOSSASIA-blue.svg)](mailto:fossasia@googlegroups.com)
 
 FOSSASIA develops Open Source software and hardware solutions with a global developer community from its base in Asia and organizes Open Technology events around the year. The mission of FOSSASIA is to improve people's lives by sharing open technologies, knowledge and resources to help build a sustainable FOSS ecosystem. 


### PR DESCRIPTION
Fixes #917 

## Problem
The Build Status badge pointed to travis-ci.org which is 
now defunct and renders as a broken image in the README.

## Solution
Replaced with the active GitHub Actions pages-build-deployment 
workflow badge.

## Screenshots
**Before** 
<img width="1284" height="600" alt="image" src="https://github.com/user-attachments/assets/12b9ac29-ecd2-4df5-b281-4684db4beea4" />

**After** 
<img width="1340" height="632" alt="image" src="https://github.com/user-attachments/assets/614095e5-26f5-4825-8704-75d1fdab1950" />

<img width="1914" height="785" alt="Screenshot 2026-03-31 001854" src="https://github.com/user-attachments/assets/32b9a09f-7798-478b-8c9c-79d3ee0822d6" />
